### PR TITLE
feat: Add sitemap, robots.txt, and llms.txt for SEO

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ vite-flare-starter/
 │       └── config/
 │           ├── features.ts  # Feature flags
 │           ├── app.ts       # App branding config
+│           ├── routes.ts    # Public routes for sitemap
 │           └── constants.ts # Shared constants (limits, timeouts)
 ├── drizzle/                 # Database migrations
 ├── wrangler.jsonc           # Workers config
@@ -237,8 +238,9 @@ echo "https://your-app.workers.dev" | npx wrangler secret put BETTER_AUTH_URL
 
 ```bash
 pnpm dev                    # Start development server
-pnpm build                  # Build for production
+pnpm build                  # Build for production (includes sitemap generation)
 pnpm deploy                 # Deploy to Cloudflare
+pnpm generate:sitemap       # Regenerate sitemap.xml manually
 pnpm db:generate:named "x"  # Generate migration
 pnpm db:migrate:local       # Apply migrations locally
 pnpm db:migrate:remote      # Apply migrations to production
@@ -335,6 +337,43 @@ const { valid, missing } = validateThemeColors(parsed.light)
 
 // Apply theme (supports custom colors)
 applyTheme('custom', 'dark', customTheme)
+```
+
+---
+
+## SEO & Discoverability
+
+The starter includes built-in SEO support with auto-generated sitemap.
+
+### Static Files (served free from edge)
+
+- `public/robots.txt` - Crawler directives
+- `public/llms.txt` - LLM crawler context (emerging standard)
+- `public/sitemap.xml` - Auto-generated from routes config
+
+### Adding New Public Routes to Sitemap
+
+When adding a new public page, update `src/shared/config/routes.ts`:
+
+```typescript
+export const publicRoutes: RouteConfig[] = [
+  // ... existing routes
+  {
+    path: '/your-new-page',
+    priority: 0.7,           // 0.0 to 1.0 (higher = more important)
+    changefreq: 'monthly',   // how often content changes
+  },
+]
+```
+
+The sitemap regenerates automatically during `pnpm build`, or manually with `pnpm generate:sitemap`.
+
+### Sitemap Base URL
+
+The sitemap uses `https://example.com` as a placeholder. Set `SITE_URL` or `BETTER_AUTH_URL` environment variable during build to customize:
+
+```bash
+SITE_URL=https://your-domain.com pnpm build
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite dev",
-    "build": "tsc && vite build",
+    "build": "tsc && npx tsx scripts/generate-sitemap.ts && vite build",
+    "generate:sitemap": "npx tsx scripts/generate-sitemap.ts",
     "preview": "wrangler dev",
     "deploy": "wrangler deploy",
     "cf:login": "wrangler login",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,53 @@
+# Vite Flare Starter
+
+> Minimal authenticated starter kit for Cloudflare Workers
+
+## Overview
+
+This is a full-stack web application starter kit built for deployment on Cloudflare Workers. It provides authentication, user management, and a modern React frontend out of the box.
+
+## Tech Stack
+
+- **Platform**: Cloudflare Workers with Static Assets
+- **Frontend**: React 19 + Vite
+- **Backend**: Hono (lightweight web framework)
+- **Database**: Cloudflare D1 (SQLite) + Drizzle ORM
+- **Authentication**: better-auth (email/password + OAuth)
+- **UI**: Tailwind CSS v4 + shadcn/ui components
+- **Data Fetching**: TanStack Query
+- **Forms**: React Hook Form + Zod validation
+
+## Features
+
+- Email/password authentication with password reset
+- Google OAuth integration (optional)
+- User profile management
+- Session management (view and revoke sessions)
+- API token management for programmatic access
+- Organization settings
+- Theme customization (8 built-in themes + custom)
+- Avatar upload to Cloudflare R2
+
+## Public Pages
+
+- `/` - Landing page
+- `/sign-in` - User sign in
+- `/sign-up` - User registration
+- `/forgot-password` - Password recovery
+- `/reset-password` - Password reset
+
+## API Endpoints
+
+- `GET /api/health` - Health check (public)
+- `/api/auth/*` - Authentication endpoints
+- `/api/settings/*` - User settings (authenticated)
+- `/api/api-tokens/*` - API token management (authenticated)
+- `/api/organization/*` - Organization settings (authenticated)
+
+## Source Code
+
+This is an open-source starter kit. For implementation details, see the GitHub repository.
+
+## Contact
+
+For questions about this starter kit, visit the project repository.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,12 @@
+# Robots.txt for Vite Flare Starter
+# https://www.robotstxt.org/
+
+# Allow all crawlers
+User-agent: *
+Allow: /
+
+# Disallow API routes (not useful for search)
+Disallow: /api/
+
+# Sitemap location (update domain when deployed)
+Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+    <lastmod>2025-12-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://example.com/sign-in</loc>
+    <lastmod>2025-12-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://example.com/sign-up</loc>
+    <lastmod>2025-12-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://example.com/forgot-password</loc>
+    <lastmod>2025-12-09</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://example.com/reset-password</loc>
+    <lastmod>2025-12-09</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,0 +1,69 @@
+/**
+ * Sitemap Generator Script
+ *
+ * Generates sitemap.xml from the routes config.
+ * Run with: pnpm generate:sitemap
+ * Automatically runs as part of: pnpm build
+ *
+ * The script reads public routes from src/shared/config/routes.ts
+ * and generates a valid XML sitemap in public/sitemap.xml
+ */
+
+import { writeFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// ESM equivalent of __dirname
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// Import routes config - use relative path for tsx execution
+import { publicRoutes } from '../src/shared/config/routes.js'
+
+/**
+ * Generate XML sitemap content
+ */
+function generateSitemapXML(baseUrl: string): string {
+  const today = new Date().toISOString().split('T')[0]
+
+  const urls = publicRoutes
+    .map(
+      (route) => `  <url>
+    <loc>${baseUrl}${route.path}</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>${route.changefreq}</changefreq>
+    <priority>${route.priority.toFixed(1)}</priority>
+  </url>`
+    )
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`
+}
+
+/**
+ * Main entry point
+ */
+function main() {
+  // Use environment variable or placeholder that works with any domain
+  // When deployed, the sitemap will use relative URLs which work on any domain
+  const baseUrl = process.env.SITE_URL || process.env.BETTER_AUTH_URL || 'https://example.com'
+
+  console.log('🗺️  Generating sitemap...')
+  console.log(`   Base URL: ${baseUrl}`)
+  console.log(`   Routes: ${publicRoutes.length}`)
+
+  const xml = generateSitemapXML(baseUrl)
+
+  // Write to public folder
+  const outputPath = resolve(__dirname, '../public/sitemap.xml')
+  writeFileSync(outputPath, xml)
+
+  console.log(`   Output: public/sitemap.xml`)
+  console.log('✅ Sitemap generated successfully!\n')
+}
+
+main()

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -1,0 +1,53 @@
+/**
+ * Route Configuration for SEO
+ *
+ * Defines public routes that should be included in the sitemap.
+ * Update this file when adding new public-facing pages.
+ *
+ * Note: Protected routes (dashboard/*) are excluded from the sitemap
+ * since they require authentication and can't be crawled.
+ */
+
+export interface RouteConfig {
+  /** Route path (e.g., '/', '/sign-in') */
+  path: string
+  /** SEO priority (0.0 to 1.0, higher = more important) */
+  priority: number
+  /** How often the page content changes */
+  changefreq: 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never'
+}
+
+/**
+ * Public routes to include in sitemap.xml
+ *
+ * Only add routes that:
+ * - Are publicly accessible (no auth required)
+ * - Should be indexed by search engines
+ */
+export const publicRoutes: RouteConfig[] = [
+  {
+    path: '/',
+    priority: 1.0,
+    changefreq: 'weekly',
+  },
+  {
+    path: '/sign-in',
+    priority: 0.8,
+    changefreq: 'monthly',
+  },
+  {
+    path: '/sign-up',
+    priority: 0.8,
+    changefreq: 'monthly',
+  },
+  {
+    path: '/forgot-password',
+    priority: 0.3,
+    changefreq: 'yearly',
+  },
+  {
+    path: '/reset-password',
+    priority: 0.3,
+    changefreq: 'yearly',
+  },
+]


### PR DESCRIPTION
- Add routes.ts config for public routes with SEO metadata
- Add generate-sitemap.ts script that runs during build
- Add robots.txt with crawler directives
- Add llms.txt for LLM crawler context
- Update build script to auto-generate sitemap
- Document SEO features in CLAUDE.md