### PR TITLE
fix(theme): correct shadcn primitives and prevent dark-mode FOUC

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,29 @@
     <!-- Theme Color -->
     <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+
+    <!--
+      Synchronous theme initialization to prevent flash of incorrect theme.
+      Mirrors getThemeStorageKey() in src/shared/config/app.ts. The localStorage
+      key is `${VITE_APP_ID}-theme`; this script defaults to the same fallback
+      app id used by appConfig. If you set VITE_APP_ID, also update APP_ID below.
+      Keep in sync with src/client/components/theme-provider.tsx and src/lib/themes.ts.
+    -->
+    <script>
+      (function () {
+        try {
+          var APP_ID = 'vite-flare-starter';
+          var stored = localStorage.getItem(APP_ID + '-theme');
+          var mode = stored || 'system';
+          if (mode === 'system') {
+            mode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+          var root = document.documentElement;
+          if (mode === 'dark') root.classList.add('dark');
+          else root.classList.remove('dark');
+        } catch (_) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/client/components/EmailVerificationBanner.tsx
+++ b/src/client/components/EmailVerificationBanner.tsx
@@ -34,17 +34,17 @@ export function EmailVerificationBanner() {
 
   if (success) {
     return (
-      <Alert className="rounded-none border-x-0 border-t-0 bg-green-500/10 border-green-500/20">
-        <CheckCircle className="h-4 w-4 text-green-600" />
+      <Alert className="rounded-none border-x-0 border-t-0 bg-green-500/10 dark:bg-green-500/15 border-green-500/20 dark:border-green-500/30">
+        <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
         <AlertDescription className="flex items-center justify-between">
-          <span className="text-green-600">
+          <span className="text-green-700 dark:text-green-300">
             Verification email sent! Check your inbox.
           </span>
           <Button
             variant="ghost"
             size="sm"
             onClick={() => setSuccess(false)}
-            className="h-6 px-2 text-green-600 hover:text-green-700 hover:bg-green-500/10"
+            className="h-6 px-2 text-green-700 dark:text-green-300 hover:text-green-800 dark:hover:text-green-200 hover:bg-green-500/10 dark:hover:bg-green-500/20"
           >
             <X className="h-4 w-4" />
           </Button>
@@ -54,10 +54,10 @@ export function EmailVerificationBanner() {
   }
 
   return (
-    <Alert className="rounded-none border-x-0 border-t-0 bg-yellow-500/10 border-yellow-500/20">
-      <Mail className="h-4 w-4 text-yellow-600" />
+    <Alert className="rounded-none border-x-0 border-t-0 bg-amber-500/10 dark:bg-amber-500/15 border-amber-500/20 dark:border-amber-500/30">
+      <Mail className="h-4 w-4 text-amber-600 dark:text-amber-400" />
       <AlertDescription className="flex items-center justify-between flex-wrap gap-2">
-        <span className="text-yellow-600">
+        <span className="text-amber-700 dark:text-amber-300">
           Please verify your email address to access all features.
         </span>
         <div className="flex items-center gap-2">
@@ -66,7 +66,7 @@ export function EmailVerificationBanner() {
             size="sm"
             onClick={handleResend}
             disabled={resending}
-            className="h-7 border-yellow-500/30 text-yellow-600 hover:bg-yellow-500/10"
+            className="h-7 border-amber-500/30 dark:border-amber-500/40 text-amber-700 dark:text-amber-300 hover:bg-amber-500/10 dark:hover:bg-amber-500/20"
           >
             {resending ? (
               <>
@@ -81,7 +81,7 @@ export function EmailVerificationBanner() {
             variant="ghost"
             size="sm"
             onClick={() => setDismissed(true)}
-            className="h-7 px-2 text-yellow-600 hover:text-yellow-700 hover:bg-yellow-500/10"
+            className="h-7 px-2 text-amber-700 dark:text-amber-300 hover:text-amber-800 dark:hover:text-amber-200 hover:bg-amber-500/10 dark:hover:bg-amber-500/20"
           >
             <X className="h-4 w-4" />
           </Button>

--- a/src/client/components/NotificationBell.tsx
+++ b/src/client/components/NotificationBell.tsx
@@ -30,13 +30,13 @@ import { formatDistanceToNow } from 'date-fns'
 function getNotificationIcon(type: string) {
   switch (type) {
     case 'warning':
-      return <AlertTriangle className="h-4 w-4 text-yellow-500" />
+      return <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
     case 'error':
       return <AlertCircle className="h-4 w-4 text-destructive" />
     case 'success':
-      return <Check className="h-4 w-4 text-green-500" />
+      return <Check className="h-4 w-4 text-green-600 dark:text-green-400" />
     default:
-      return <Info className="h-4 w-4 text-blue-500" />
+      return <Info className="h-4 w-4 text-blue-600 dark:text-blue-400" />
   }
 }
 

--- a/src/client/components/PasswordStrengthMeter.tsx
+++ b/src/client/components/PasswordStrengthMeter.tsx
@@ -41,10 +41,10 @@ export function PasswordStrengthMeter({
             className={cn(
               'text-xs font-medium',
               strength.score === 0 && 'text-destructive',
-              strength.score === 1 && 'text-orange-500',
-              strength.score === 2 && 'text-yellow-500',
-              strength.score === 3 && 'text-green-500',
-              strength.score === 4 && 'text-emerald-500'
+              strength.score === 1 && 'text-orange-600 dark:text-orange-400',
+              strength.score === 2 && 'text-amber-600 dark:text-amber-400',
+              strength.score === 3 && 'text-green-600 dark:text-green-400',
+              strength.score === 4 && 'text-emerald-600 dark:text-emerald-400'
             )}
           >
             {strength.label}
@@ -66,7 +66,7 @@ export function PasswordStrengthMeter({
               key={index}
               className={cn(
                 'flex items-center gap-1.5 text-xs',
-                req.met ? 'text-green-600' : 'text-muted-foreground'
+                req.met ? 'text-green-600 dark:text-green-400' : 'text-muted-foreground'
               )}
             >
               {req.met ? (

--- a/src/client/lib/status-colors.ts
+++ b/src/client/lib/status-colors.ts
@@ -1,0 +1,43 @@
+/**
+ * Semantic status colour classes that work in both light and dark mode.
+ *
+ * Use these constants instead of bare Tailwind colour utilities (e.g. `text-green-500`)
+ * for status indicators (success, info, warning, danger). They encode the dark-mode
+ * counterpart so contrast remains correct under either theme.
+ *
+ * The shadcn semantic tokens (`bg-primary`, `bg-destructive`, etc.) should still be
+ * preferred when applicable; this helper exists for the cases where we need a
+ * specific traffic-light hue (e.g. distinguishing create vs. update vs. delete).
+ */
+
+export type StatusKind = 'success' | 'info' | 'warning' | 'danger'
+
+/** Plain text colour for icons and inline labels. */
+export const STATUS_TEXT: Record<StatusKind, string> = {
+  success: 'text-green-600 dark:text-green-400',
+  info: 'text-blue-600 dark:text-blue-400',
+  warning: 'text-amber-600 dark:text-amber-400',
+  danger: 'text-red-600 dark:text-red-400',
+}
+
+/** Soft tinted background + matching text + border (alerts, badges, banners). */
+export const STATUS_SOFT_BG: Record<StatusKind, string> = {
+  success:
+    'bg-green-500/10 dark:bg-green-500/15 text-green-700 dark:text-green-300 border-green-500/30',
+  info:
+    'bg-blue-500/10 dark:bg-blue-500/15 text-blue-700 dark:text-blue-300 border-blue-500/30',
+  warning:
+    'bg-amber-500/10 dark:bg-amber-500/15 text-amber-700 dark:text-amber-300 border-amber-500/30',
+  danger:
+    'bg-red-500/10 dark:bg-red-500/15 text-red-700 dark:text-red-300 border-red-500/30',
+}
+
+/** Solid filled status (e.g. completed step indicators on coloured circles). */
+export const STATUS_SOLID: Record<StatusKind, string> = {
+  success:
+    'bg-green-600 dark:bg-green-500 text-white border-green-600 dark:border-green-500',
+  info: 'bg-blue-600 dark:bg-blue-500 text-white border-blue-600 dark:border-blue-500',
+  warning:
+    'bg-amber-500 dark:bg-amber-500 text-white border-amber-500',
+  danger: 'bg-red-600 dark:bg-red-500 text-white border-red-600 dark:border-red-500',
+}

--- a/src/client/modules/activity/pages/ActivityPage.tsx
+++ b/src/client/modules/activity/pages/ActivityPage.tsx
@@ -52,17 +52,17 @@ const ACTION_ICONS: Record<Activity['action'], React.ElementType> = {
 }
 
 const ACTION_COLORS: Record<Activity['action'], string> = {
-  create: 'bg-green-500/10 text-green-600',
-  update: 'bg-blue-500/10 text-blue-600',
-  delete: 'bg-red-500/10 text-red-600',
-  archive: 'bg-yellow-500/10 text-yellow-600',
-  restore: 'bg-purple-500/10 text-purple-600',
-  import: 'bg-cyan-500/10 text-cyan-600',
-  export: 'bg-orange-500/10 text-orange-600',
-  assign: 'bg-emerald-500/10 text-emerald-600',
-  unassign: 'bg-pink-500/10 text-pink-600',
-  view: 'bg-slate-500/10 text-slate-600',
-  convert: 'bg-indigo-500/10 text-indigo-600',
+  create: 'bg-green-500/10 dark:bg-green-500/15 text-green-600 dark:text-green-400',
+  update: 'bg-blue-500/10 dark:bg-blue-500/15 text-blue-600 dark:text-blue-400',
+  delete: 'bg-red-500/10 dark:bg-red-500/15 text-red-600 dark:text-red-400',
+  archive: 'bg-amber-500/10 dark:bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  restore: 'bg-purple-500/10 dark:bg-purple-500/15 text-purple-600 dark:text-purple-400',
+  import: 'bg-cyan-500/10 dark:bg-cyan-500/15 text-cyan-600 dark:text-cyan-400',
+  export: 'bg-orange-500/10 dark:bg-orange-500/15 text-orange-600 dark:text-orange-400',
+  assign: 'bg-emerald-500/10 dark:bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  unassign: 'bg-pink-500/10 dark:bg-pink-500/15 text-pink-600 dark:text-pink-400',
+  view: 'bg-slate-500/10 dark:bg-slate-500/20 text-slate-600 dark:text-slate-300',
+  convert: 'bg-indigo-500/10 dark:bg-indigo-500/15 text-indigo-600 dark:text-indigo-400',
 }
 
 function formatTime(dateString: string): string {

--- a/src/client/modules/auth/VerifyEmailPage.tsx
+++ b/src/client/modules/auth/VerifyEmailPage.tsx
@@ -145,7 +145,7 @@ export function VerifyEmailPage() {
           <CardContent>
             {resendSuccess ? (
               <div className="text-center space-y-4">
-                <div className="p-3 bg-green-500/10 text-green-600 rounded-md">
+                <div className="p-3 bg-green-500/10 dark:bg-green-500/15 text-green-700 dark:text-green-300 rounded-md border border-green-500/30">
                   Verification email sent! Check your inbox.
                 </div>
                 <p className="text-sm text-muted-foreground">

--- a/src/client/modules/chat/components/chat-ui/AlertBox.tsx
+++ b/src/client/modules/chat/components/chat-ui/AlertBox.tsx
@@ -1,5 +1,6 @@
 import { Info, CheckCircle2, AlertTriangle, XCircle } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { STATUS_SOFT_BG } from '@/client/lib/status-colors'
 
 interface Props {
   type?: 'info' | 'success' | 'warning' | 'error'
@@ -9,9 +10,9 @@ interface Props {
 
 const ICONS = { info: Info, success: CheckCircle2, warning: AlertTriangle, error: XCircle }
 const STYLES = {
-  info: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300',
-  success: 'border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300',
-  warning: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  info: STATUS_SOFT_BG.info,
+  success: STATUS_SOFT_BG.success,
+  warning: STATUS_SOFT_BG.warning,
   error: 'border-destructive/30 bg-destructive/10 text-destructive',
 }
 

--- a/src/client/modules/chat/components/chat-ui/ArtifactViewer.tsx
+++ b/src/client/modules/chat/components/chat-ui/ArtifactViewer.tsx
@@ -11,6 +11,31 @@
 import { useState, useRef, useEffect } from 'react'
 import { Code2, Eye, Copy, Check, ExternalLink } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useTheme } from '@/client/components/theme-provider'
+
+/**
+ * Read the resolved value of a CSS custom property on the document root.
+ * Returns undefined during SSR / before hydration.
+ */
+function readCssVar(name: string): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+  return v || undefined
+}
+
+/** Resolve whether the current theme is dark by inspecting the `.dark` class. */
+function useResolvedDarkMode(): boolean {
+  const { theme } = useTheme()
+  const [isDark, setIsDark] = useState(() => {
+    if (typeof document === 'undefined') return false
+    return document.documentElement.classList.contains('dark')
+  })
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    setIsDark(document.documentElement.classList.contains('dark'))
+  }, [theme])
+  return isDark
+}
 
 interface ArtifactData {
   _artifact: true
@@ -34,6 +59,7 @@ export function ArtifactViewer({ artifact }: Props) {
   const [copied, setCopied] = useState(false)
   const [autoHeight, setAutoHeight] = useState<number | null>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
+  const isDark = useResolvedDarkMode()
 
   const height = autoHeight || artifact.height || 400
 
@@ -54,7 +80,7 @@ export function ArtifactViewer({ artifact }: Props) {
     setTimeout(() => setCopied(false), 2000)
   }
 
-  const iframeSrc = buildIframeSrc(artifact)
+  const iframeSrc = buildIframeSrc(artifact, isDark)
 
   return (
     <div className="my-2 rounded-lg border border-border overflow-hidden">
@@ -72,7 +98,7 @@ export function ArtifactViewer({ artifact }: Props) {
             {showCode ? <Eye className="size-3.5" /> : <Code2 className="size-3.5" />}
           </button>
           <button onClick={handleCopy} className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors" title="Copy code">
-            {copied ? <Check className="size-3.5 text-green-500" /> : <Copy className="size-3.5" />}
+            {copied ? <Check className="size-3.5 text-green-600 dark:text-green-400" /> : <Copy className="size-3.5" />}
           </button>
           {artifact.type === 'html' && (
             <button
@@ -92,9 +118,9 @@ export function ArtifactViewer({ artifact }: Props) {
       {showCode ? (
         <pre className="p-3 text-xs font-mono overflow-auto max-h-96 bg-background">{artifact.code}</pre>
       ) : (
-        <div className="bg-muted/50 dark:bg-[#0f1117]">
+        <div className="bg-muted/50">
           {artifact.type === 'svg' ? (
-            <SvgRenderer code={artifact.code} height={height} />
+            <SvgRenderer code={artifact.code} height={height} isDark={isDark} />
           ) : (
             <iframe
               ref={iframeRef}
@@ -110,10 +136,23 @@ export function ArtifactViewer({ artifact }: Props) {
   )
 }
 
+/** Resolve theme-aware iframe colours from the page's CSS variables. */
+function resolveIframeColors(isDark: boolean): { bg: string; fg: string } {
+  // Fall back to safe defaults if computed styles can't be read yet (SSR / first paint).
+  const fallback = isDark
+    ? { bg: 'hsl(222.2 84% 4.9%)', fg: 'hsl(210 40% 98%)' }
+    : { bg: 'hsl(0 0% 100%)', fg: 'hsl(222.2 84% 4.9%)' }
+  return {
+    bg: readCssVar('--background') ?? fallback.bg,
+    fg: readCssVar('--foreground') ?? fallback.fg,
+  }
+}
+
 /** Render SVG safely via an iframe to avoid script injection */
-function SvgRenderer({ code, height }: { code: string; height: number }) {
+function SvgRenderer({ code, height, isDark }: { code: string; height: number; isDark: boolean }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
-  const html = `<!DOCTYPE html><html><head><style>body{margin:0;padding:16px;background:#0f1117;display:flex;justify-content:center;align-items:center;min-height:100vh;}</style></head><body>${code}</body></html>`
+  const { bg, fg } = resolveIframeColors(isDark)
+  const html = `<!DOCTYPE html><html><head><style>body{margin:0;padding:16px;background:${bg};color:${fg};display:flex;justify-content:center;align-items:center;min-height:100vh;}</style></head><body>${code}</body></html>`
   return (
     <iframe
       ref={iframeRef}
@@ -125,17 +164,19 @@ function SvgRenderer({ code, height }: { code: string; height: number }) {
   )
 }
 
-function buildIframeSrc(artifact: ArtifactData): string {
+function buildIframeSrc(artifact: ArtifactData, isDark: boolean): string {
   const resizeScript = `<script>new ResizeObserver(()=>{parent.postMessage({type:'artifact-resize',height:document.documentElement.scrollHeight},'*')}).observe(document.documentElement)<\/script>`
 
   if (artifact.type === 'mermaid') {
+    const { bg, fg } = resolveIframeColors(isDark)
+    const mermaidTheme = isDark ? 'dark' : 'default'
     return `<!DOCTYPE html>
 <html><head>
-<style>body{margin:0;padding:16px;background:#0f1117;color:#e2e8f0;font-family:system-ui;display:flex;justify-content:center;}</style>
+<style>body{margin:0;padding:16px;background:${bg};color:${fg};font-family:system-ui;display:flex;justify-content:center;}</style>
 <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"><\/script>
 </head><body>
 <pre class="mermaid">${escapeHtml(artifact.code)}</pre>
-<script>mermaid.initialize({startOnLoad:true,theme:'dark'});<\/script>
+<script>mermaid.initialize({startOnLoad:true,theme:'${mermaidTheme}'});<\/script>
 ${resizeScript}
 </body></html>`
   }

--- a/src/client/modules/chat/components/chat-ui/DocumentDownload.tsx
+++ b/src/client/modules/chat/components/chat-ui/DocumentDownload.tsx
@@ -22,9 +22,9 @@ export function isDocument(output: unknown): output is DocumentData {
 }
 
 const FORMAT_META: Record<string, { icon: typeof FileText; label: string; color: string; mime: string }> = {
-  docx: { icon: FileText, label: 'Word Document', color: 'text-blue-500', mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' },
-  xlsx: { icon: FileSpreadsheet, label: 'Excel Spreadsheet', color: 'text-green-500', mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' },
-  csv: { icon: Table2, label: 'CSV File', color: 'text-amber-500', mime: 'text/csv' },
+  docx: { icon: FileText, label: 'Word Document', color: 'text-blue-600 dark:text-blue-400', mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' },
+  xlsx: { icon: FileSpreadsheet, label: 'Excel Spreadsheet', color: 'text-green-600 dark:text-green-400', mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' },
+  csv: { icon: Table2, label: 'CSV File', color: 'text-amber-600 dark:text-amber-400', mime: 'text/csv' },
 }
 
 function formatSize(bytes: number): string {

--- a/src/client/modules/chat/components/chat-ui/ProgressTracker.tsx
+++ b/src/client/modules/chat/components/chat-ui/ProgressTracker.tsx
@@ -1,5 +1,6 @@
 import { Check } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { STATUS_SOLID } from '@/client/lib/status-colors'
 
 interface Step {
   label: string
@@ -31,7 +32,7 @@ export function ProgressTracker({ title, steps }: Props) {
             <div
               className={cn(
                 'mt-0.5 size-5 rounded-full flex items-center justify-center text-[10px] font-semibold shrink-0',
-                step.status === 'completed' && 'bg-green-500 text-white',
+                step.status === 'completed' && STATUS_SOLID.success,
                 step.status === 'current' && 'bg-primary text-primary-foreground',
                 step.status === 'upcoming' && 'bg-muted text-muted-foreground'
               )}

--- a/src/client/modules/chat/components/chat-ui/Timeline.tsx
+++ b/src/client/modules/chat/components/chat-ui/Timeline.tsx
@@ -1,5 +1,6 @@
 import { Check, Circle, Clock } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { STATUS_SOLID } from '@/client/lib/status-colors'
 
 interface Event {
   title: string
@@ -15,7 +16,7 @@ interface Props {
 
 const ICONS = { completed: Check, current: Clock, upcoming: Circle }
 const COLORS = {
-  completed: 'bg-green-500 text-white border-green-500',
+  completed: STATUS_SOLID.success,
   current: 'bg-primary text-primary-foreground border-primary',
   upcoming: 'bg-background text-muted-foreground border-border',
 }

--- a/src/client/modules/chat/components/chat-ui/ToolApproval.tsx
+++ b/src/client/modules/chat/components/chat-ui/ToolApproval.tsx
@@ -19,10 +19,10 @@ export function ToolApproval({ toolName, args, onApprove, onDeny }: Props) {
   const friendlyName = toolName.replace(/_/g, ' ')
 
   return (
-    <div className="my-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+    <div className="my-2 rounded-lg border border-amber-500/30 dark:border-amber-500/40 bg-amber-500/5 dark:bg-amber-500/10 p-3">
       <div className="flex items-start gap-3">
-        <div className="rounded-md bg-amber-500/10 p-2">
-          <ShieldAlert className="size-4 text-amber-500" />
+        <div className="rounded-md bg-amber-500/10 dark:bg-amber-500/15 p-2">
+          <ShieldAlert className="size-4 text-amber-600 dark:text-amber-400" />
         </div>
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium">Approval required: {friendlyName}</div>

--- a/src/client/modules/files/components/FileList.tsx
+++ b/src/client/modules/files/components/FileList.tsx
@@ -161,10 +161,10 @@ export function FileList({ files, isLoading }: FileListProps) {
               <div
                 className={cn(
                   'flex items-center justify-center h-10 w-10 rounded-lg',
-                  iconType === 'image' && 'bg-purple-500/10 text-purple-500',
-                  iconType === 'document' && 'bg-red-500/10 text-red-500',
-                  iconType === 'code' && 'bg-blue-500/10 text-blue-500',
-                  iconType === 'archive' && 'bg-amber-500/10 text-amber-500',
+                  iconType === 'image' && 'bg-purple-500/10 dark:bg-purple-500/15 text-purple-600 dark:text-purple-400',
+                  iconType === 'document' && 'bg-red-500/10 dark:bg-red-500/15 text-red-600 dark:text-red-400',
+                  iconType === 'code' && 'bg-blue-500/10 dark:bg-blue-500/15 text-blue-600 dark:text-blue-400',
+                  iconType === 'archive' && 'bg-amber-500/10 dark:bg-amber-500/15 text-amber-600 dark:text-amber-400',
                   iconType === 'file' && 'bg-muted text-muted-foreground'
                 )}
               >
@@ -176,7 +176,7 @@ export function FileList({ files, isLoading }: FileListProps) {
                 <div className="flex items-center gap-2">
                   <p className="font-medium truncate">{file.name}</p>
                   {file.isPublic ? (
-                    <Globe className="h-3.5 w-3.5 text-green-500 flex-shrink-0" />
+                    <Globe className="h-3.5 w-3.5 text-green-600 dark:text-green-400 flex-shrink-0" />
                   ) : (
                     <Lock className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
                   )}

--- a/src/client/pages/LandingPage.tsx
+++ b/src/client/pages/LandingPage.tsx
@@ -140,15 +140,15 @@ export function LandingPage() {
 
             <div className="mt-8 flex items-center gap-6 text-sm text-muted-foreground">
               <div className="flex items-center gap-2">
-                <div className="h-2 w-2 rounded-full bg-green-500" />
+                <div className="h-2 w-2 rounded-full bg-green-500 dark:bg-green-400" />
                 MIT Licensed
               </div>
               <div className="flex items-center gap-2">
-                <div className="h-2 w-2 rounded-full bg-blue-500" />
+                <div className="h-2 w-2 rounded-full bg-blue-500 dark:bg-blue-400" />
                 TypeScript
               </div>
               <div className="flex items-center gap-2">
-                <div className="h-2 w-2 rounded-full bg-orange-500" />
+                <div className="h-2 w-2 rounded-full bg-orange-500 dark:bg-orange-400" />
                 Cloudflare Ready
               </div>
             </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -14,7 +14,7 @@ const badgeVariants = cva(
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "border-transparent bg-destructive text-destructive-foreground [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -51,7 +51,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-background shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>


### PR DESCRIPTION
- Slider thumb: bg-white -> bg-background (visible on light tracks under
  custom themes).
- Button & Badge destructive variants: text-white -> text-destructive-
  foreground, honouring the existing CSS variable.
- index.html: add a synchronous theme-init script before React mounts so
  light-mode users no longer flash dark on first paint.

https://claude.ai/code/session_01KkSvbAchcihBP7JPwuksed