### PR TITLE
fix(auth): email verification & SPA login race condition (#6, #7)

### DIFF
--- a/src/client/modules/auth/SignInPage.tsx
+++ b/src/client/modules/auth/SignInPage.tsx
@@ -12,7 +12,7 @@
  * The UI automatically shows/hides email form based on server config.
  */
 import { useState, useEffect, FormEvent } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { authClient } from '@/client/lib/auth'
 import { Button } from '@/components/ui/button'
 import {
@@ -38,7 +38,6 @@ interface AuthConfig {
 }
 
 export function SignInPage() {
-  const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -77,8 +76,10 @@ export function SignInPage() {
         password,
       })
 
-      // Redirect to dashboard on success
-      navigate('/dashboard')
+      // Full page reload so useSession() picks up the auth cookie
+      // (React Router navigate() does a client-side transition without reload,
+      //  which means the session cookie isn't read by useSession() on the dashboard)
+      window.location.href = '/dashboard'
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to sign in')
     } finally {

--- a/src/server/modules/auth/index.ts
+++ b/src/server/modules/auth/index.ts
@@ -83,7 +83,7 @@ export function createAuth(
     // See CLAUDE.md for configuration: ENABLE_EMAIL_LOGIN=true, ENABLE_EMAIL_SIGNUP=true
     emailAndPassword: {
       enabled: emailLoginEnabled,
-      requireEmailVerification: true, // Users must verify email before signing in
+      requireEmailVerification: !!(env.EMAIL_API_KEY && env.EMAIL_FROM), // Only require verification when email provider is configured
       disableSignUp: !emailSignupEnabled,
 
       // Password reset flow


### PR DESCRIPTION
## Changes

Fixes two auth bugs that prevent users from logging in:

### Fix #7: Email verification blocks login when no email provider configured

**Root cause:**  is hardcoded at . When `EMAIL_API_KEY` is not set, verification emails silently fail (the send handler just logs a warning and returns). Users sign up, get `emailVerified: false`, and then `signIn.email()` returns `EMAIL_NOT_VERIFIED` forever — no way to resolve.

**Fix:** Make verification conditional on email infrastructure:
```typescript
requireEmailVerification: !!(env.EMAIL_API_KEY && env.EMAIL_FROM),
```

### Fix #6: SPA login race condition — session cookie not picked up

**Root cause:** `SignInPage.tsx` uses `navigate('/dashboard')` after `signIn.email()` succeeds. React Router's `navigate()` does a client-side transition without page reload, so `useSession()` never picks up the new auth cookie. The user sees login succeed but gets redirected back to `/sign-in`.

**Fix:** Replace with `window.location.href = '/dashboard'` to force a full page reload. Also removed the now-unused `useNavigate` import.

### Files changed
- `src/server/modules/auth/index.ts` — conditional `requireEmailVerification`
- `src/client/modules/auth/SignInPage.tsx` — full reload after login + cleanup unused import