### PR TITLE
fix(chat): look up vision capability from model catalogue, not model ID

### DIFF
--- a/src/client/modules/chat/pages/ChatPage.tsx
+++ b/src/client/modules/chat/pages/ChatPage.tsx
@@ -8,7 +8,8 @@
  */
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/client/lib/api-client'
 import { Button } from '@/components/ui/button'
 import {
   PromptInput,
@@ -108,7 +109,17 @@ export function ChatPage() {
   // Vision support check — gates whether we accept image attachments at the picker.
   // Non-image files (PDF/DOCX/audio/text) flow through convertToMarkdown on the
   // server and are safe for every model. The API endpoint also validates.
-  const supportsVision = model.includes('gemma') || model.includes('gemini') || model.includes('claude') || model.includes('gpt')
+  //
+  // Read the authoritative `supportsVision` flag from the server's model
+  // catalogue (shared ['ai-models'] TanStack cache with ModelSelector — no
+  // extra request). Default to `true` on first paint before the catalogue
+  // loads so the server, not the UI, has the final say.
+  const { data: modelsData } = useQuery({
+    queryKey: ['ai-models'],
+    queryFn: () => apiClient.get<{ models: Array<{ id: string; supportsVision: boolean }>; recommended: string }>('/api/ai/models'),
+    staleTime: 5 * 60 * 1000,
+  })
+  const supportsVision = modelsData?.models.find((m) => m.id === model)?.supportsVision ?? true
   // Accept is "everything" for vision-capable models, or "everything minus images"
   // for text-only models. Drop, paste, and the + menu all respect this.
   const acceptString = supportsVision


### PR DESCRIPTION
## Summary

Fixes the chat attachment picker rejecting JPG/PNG on every Workers AI model whose ID doesn't contain `gemma|gemini|claude|gpt` — most notably the default model `@cf/moonshotai/kimi-k2.5`.

- `ChatPage.tsx` was deciding `supportsVision` via a substring match on the model ID.
- Kimi K2.5 failed the match, so `image/*` was stripped from the accept list — only PDFs/docs were accepted.
- Switched to the authoritative `supportsVision` flag from `/api/ai/models` (same `['ai-models']` TanStack cache the ModelSelector already uses — no extra request).
- Defaults to `true` on first paint before the catalogue loads; the server-side validator has the final say.

## Repro (before fix)

1. `/dashboard/chat` with default model (Kimi K2.5).
2. Click Attach → "Add photos or files".
3. OS picker shows PDFs only; JPG/PNG greyed out.

## After fix

Picker respects each model's real capability. If the model's `supportsVision` flag is `true` in the catalogue, images attach; if `false`, they don't — regardless of provider.

## Test plan

- [ ] Load `/dashboard/chat` with Kimi K2.5 selected → picker accepts JPG/PNG
- [ ] Switch to a non-vision model (e.g. `@cf/qwen/qwq-32b`) → picker excludes images
- [ ] Switch to Claude/Gemini → picker accepts images (unchanged behaviour)
- [ ] First-paint before `/api/ai/models` resolves → picker allows images; server validation still rejects if unsupported

🤖 Generated with [Claude Code](https://claude.com/claude-code)