### PR TITLE
chore: overnight log bail 2026-04-20T23:16Z

### DIFF
--- a/.jez/artifacts/overnight-log.md
+++ b/.jez/artifacts/overnight-log.md
@@ -60,6 +60,9 @@ Pick the next AVAILABLE task in ID order. Mark it in-progress in your iteration 
 
 *(Append entries here. Newest at top.)*
 
+### Bail — 2026-04-20T23:16Z
+Bailed — past 2am local (23:16 UTC > 16:00 UTC cutoff) and no tasks left.
+
 ### Bail — 2026-04-20T22:23Z
 Bailed — past 2am local (22:23 UTC > 16:00 UTC cutoff) and no tasks left.
 


### PR DESCRIPTION
## Summary

- Appends bail entry `2026-04-20T23:16Z` to overnight-log.md (past 2am Sydney cutoff, no tasks left)
- All candidate tasks remain DONE/SKIP/BLOCKED — nothing to implement

## Git note for Jez

The local repository was in an unusual state: ~51 overnight agent commits had accumulated on a **detached HEAD** with no common ancestor with the old `main`. It appears someone force-pushed this detached HEAD chain to `origin/main` at some point, so `origin/main` now reflects all the bail/feature history from April 18–20.

This branch (`agent-log-2026-04-20`) was branched off the current `origin/main` tip (`dc973eb`) and adds only the single missing bail entry. Safe to fast-forward merge.

## Test plan

- [ ] No code changes — log file only
- [ ] Verify overnight-log.md has `### Bail — 2026-04-20T23:16Z` at top of Iteration log section