### PR TITLE
feat(ai): direct Qwen (DashScope) and HuggingFace provider routes

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -100,6 +100,37 @@ NODE_ENV=development
 # Never commit production secrets to git!
 
 # ============================================
+# AI Provider API Keys (optional)
+# ============================================
+# Workers AI (env.AI binding) is free and needs no key. Set the keys for the
+# providers you actually want to call. One OPENROUTER_API_KEY unlocks every
+# `provider/model` ID in src/shared/config/models.ts. The direct keys below
+# are useful when you want native billing, lower latency, or extra models
+# OpenRouter doesn't proxy.
+
+# Anthropic direct (claude-* model IDs)
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI direct (gpt-*, o1-*, o3-*, o4-* model IDs)
+# OPENAI_API_KEY=sk-...
+
+# Google AI Studio direct (gemini-* model IDs)
+# GOOGLE_AI_API_KEY=AIza...
+
+# Alibaba DashScope direct (dashscope/* model IDs — Qwen Max/Plus/Turbo, VL, Coder)
+# Sign up: https://dashscope.console.aliyun.com/ (international region)
+# Endpoint used: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+# DASHSCOPE_API_KEY=sk-...
+
+# HuggingFace Inference Providers direct (huggingface/* model IDs)
+# Generate token: https://huggingface.co/settings/tokens (read scope is enough)
+# Endpoint used: https://router.huggingface.co/v1
+# HUGGINGFACE_API_KEY=hf_...
+
+# OpenRouter (any other provider/model ID — the simplest option)
+# OPENROUTER_API_KEY=sk-or-...
+
+# ============================================
 # Google Places (optional — powers places_search + show_map)
 # ============================================
 # Pairs with the show_map inline UI tool to render map answers like claude.ai.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,7 +607,14 @@ Use for: heavy ML inference, video processing, anything that exceeds Workers CPU
 | **xAI** | Grok 4.1 Fast | Via OpenRouter |
 | **Z.AI** | GLM 5 | Via OpenRouter |
 
-One `OPENROUTER_API_KEY` unlocks all non-Workers-AI models. Direct-provider SDKs (`@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/google`) are kept as fallbacks if you prefer native routing.
+Plus two direct API routes (no OpenRouter middleman) for users who want native billing or models OpenRouter doesn't proxy:
+
+| Source | Models | ID prefix | Required key |
+|--------|--------|-----------|--------------|
+| **Alibaba DashScope** (Qwen direct) | Qwen 3.6 Max / Plus / Turbo, Qwen3 Coder Plus, Qwen-VL Max | `dashscope/` | `DASHSCOPE_API_KEY` |
+| **HuggingFace Inference Providers** | Llama 3.3 70B, Qwen2.5 72B, DeepSeek V3, Mistral Nemo (anything on the HF Router) | `huggingface/owner/repo` | `HUGGINGFACE_API_KEY` |
+
+One `OPENROUTER_API_KEY` unlocks all `provider/model` IDs. Direct-provider SDKs (`@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/google`) are kept as fallbacks for native routing. DashScope + HuggingFace both speak OpenAI-compatible mode, so they're wired via `createOpenAI({ baseURL })` rather than dedicated SDK packages — no extra dependencies. To add another OpenAI-compatible provider (Together, Groq, Fireworks, Cerebras), copy the dashscope/huggingface block in `src/server/lib/ai/providers.ts:resolveModel`.
 
 AI features in the chat module: streaming, tool calling, reasoning extraction, vision (image attachments), structured output, token usage logging, message metadata, regenerate, **message editing** (truncate + re-send), **conversation search** (FTS5), **conversation export** (JSON/Markdown), response duration display, conversation persistence, MCP integration, MCP-UI rendering, **sources footer** (claude.ai-style citation strip aggregated from web_search / gmail_search / drive_search / places_search outputs plus native `source-url` / `source-document` parts), **per-tool telemetry** (`ai_tool_calls` D1 table + admin "Tool errors" tab), **privileged-tool gating** (`gmail_send` / `run_shell` / `drive_delete` etc. hidden unless user intent is clear), **single-retry tool repair** (`experimental_repairToolCall` logs then emits parse error — no cost-bearing retry yet).
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -108,6 +108,8 @@ export interface Env {
   ANTHROPIC_API_KEY?: string  // Claude models
   OPENAI_API_KEY?: string     // GPT models
   GOOGLE_AI_API_KEY?: string  // Gemini models
+  DASHSCOPE_API_KEY?: string  // Alibaba Qwen models direct (dashscope/* prefix)
+  HUGGINGFACE_API_KEY?: string // HuggingFace Inference Providers direct (huggingface/* prefix)
   OPENROUTER_API_KEY?: string // Any model via OpenRouter (single key)
 
   // Browser Rendering (optional — enables browser_* agent tools)

--- a/src/server/lib/ai/providers.ts
+++ b/src/server/lib/ai/providers.ts
@@ -13,7 +13,21 @@ export interface ProviderEnv {
   OPENAI_API_KEY?: string
   GOOGLE_AI_API_KEY?: string
   OPENROUTER_API_KEY?: string
+  DASHSCOPE_API_KEY?: string
+  HUGGINGFACE_API_KEY?: string
 }
+
+/**
+ * Alibaba DashScope — international endpoint, OpenAI-compatible mode.
+ * China-region keys should override via `DASHSCOPE_BASE_URL` (not yet wired).
+ */
+const DASHSCOPE_BASE_URL = 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
+
+/**
+ * HuggingFace Inference Providers router — OpenAI-compatible, fans out to the
+ * cheapest available provider for each model (Sambanova, Together, Fireworks…).
+ */
+const HUGGINGFACE_BASE_URL = 'https://router.huggingface.co/v1'
 
 export function resolveModel(env: ProviderEnv, modelId: string) {
   // Workers AI — native binding, free.
@@ -27,6 +41,23 @@ export function resolveModel(env: ProviderEnv, modelId: string) {
     if (!env.OPENROUTER_API_KEY) throw new Error(`OPENROUTER_API_KEY required for model: ${modelId}`)
     const openrouter = createOpenRouter({ apiKey: env.OPENROUTER_API_KEY })
     return openrouter(modelId.replace('openrouter/', ''))
+  }
+
+  // Alibaba Qwen direct via DashScope (OpenAI-compatible). Must be checked
+  // before the generic `provider/model → openrouter` rule below.
+  if (modelId.startsWith('dashscope/')) {
+    if (!env.DASHSCOPE_API_KEY) throw new Error(`DASHSCOPE_API_KEY required for model: ${modelId}`)
+    const dashscope = createOpenAI({ apiKey: env.DASHSCOPE_API_KEY, baseURL: DASHSCOPE_BASE_URL })
+    return dashscope(modelId.replace('dashscope/', ''))
+  }
+
+  // HuggingFace Inference Providers direct. The downstream model ID can itself
+  // contain a slash (e.g. `meta-llama/Llama-3.3-70B-Instruct`), so we strip
+  // only the `huggingface/` prefix and forward the rest verbatim.
+  if (modelId.startsWith('huggingface/')) {
+    if (!env.HUGGINGFACE_API_KEY) throw new Error(`HUGGINGFACE_API_KEY required for model: ${modelId}`)
+    const hf = createOpenAI({ apiKey: env.HUGGINGFACE_API_KEY, baseURL: HUGGINGFACE_BASE_URL })
+    return hf(modelId.replace('huggingface/', ''))
   }
 
   // `provider/model` shape (e.g. `anthropic/claude-sonnet-4.6`) → OpenRouter.
@@ -66,6 +97,8 @@ export function getAvailableProviders(env: ProviderEnv): string[] {
   if (env.ANTHROPIC_API_KEY) providers.push('anthropic')
   if (env.OPENAI_API_KEY) providers.push('openai')
   if (env.GOOGLE_AI_API_KEY) providers.push('google')
+  if (env.DASHSCOPE_API_KEY) providers.push('dashscope')
+  if (env.HUGGINGFACE_API_KEY) providers.push('huggingface')
   if (env.OPENROUTER_API_KEY) providers.push('openrouter')
   return providers
 }

--- a/src/shared/config/models.ts
+++ b/src/shared/config/models.ts
@@ -11,6 +11,11 @@
  * - `@cf/...`  → free Cloudflare Workers AI (no API key required)
  * - `provider/model` (e.g. `anthropic/claude-sonnet-4.6`) → routed through
  *   OpenRouter. Requires OPENROUTER_API_KEY secret.
+ * - `dashscope/...` → Alibaba Qwen direct via DashScope (OpenAI-compatible).
+ *   Requires DASHSCOPE_API_KEY. Cheaper than OpenRouter for Qwen-only use.
+ * - `huggingface/owner/model` → HuggingFace Inference Providers router
+ *   (OpenAI-compatible). Requires HUGGINGFACE_API_KEY. Unlocks the long
+ *   tail of open models (Llama, Mistral, Qwen weights, DeepSeek, etc).
  *
  * Browse the full catalogue at https://models.flared.au/ and just paste the
  * `id` field of any model you want.
@@ -60,10 +65,42 @@ export const OPENROUTER_MODELS = [
   'z-ai/glm-5',
 ] as const
 
+/**
+ * Alibaba Qwen via DashScope direct (requires DASHSCOPE_API_KEY).
+ *
+ * IDs are the model name DashScope's OpenAI-compatible endpoint expects —
+ * see https://help.aliyun.com/zh/model-studio/getting-started/models for the
+ * current catalogue. The international endpoint is used by default.
+ */
+export const DASHSCOPE_MODELS = [
+  'dashscope/qwen3.6-max',
+  'dashscope/qwen3.6-plus',
+  'dashscope/qwen3.6-turbo',
+  'dashscope/qwen3-coder-plus',
+  'dashscope/qwen-vl-max-latest',
+] as const
+
+/**
+ * HuggingFace Inference Providers (requires HUGGINGFACE_API_KEY).
+ *
+ * The router fans out to whichever provider currently serves the model
+ * cheapest (Sambanova, Together, Fireworks, Replicate, …). Pick any
+ * `owner/repo` from https://huggingface.co/models?inference_provider=all
+ * that supports chat-completions.
+ */
+export const HUGGINGFACE_MODELS = [
+  'huggingface/meta-llama/Llama-3.3-70B-Instruct',
+  'huggingface/Qwen/Qwen2.5-72B-Instruct',
+  'huggingface/deepseek-ai/DeepSeek-V3',
+  'huggingface/mistralai/Mistral-Nemo-Instruct-2407',
+] as const
+
 /** Every enabled model ID — used by the chat model selector. */
 export const ENABLED_MODEL_IDS: readonly string[] = [
   ...WORKERS_AI_MODELS,
   ...OPENROUTER_MODELS,
+  ...DASHSCOPE_MODELS,
+  ...HUGGINGFACE_MODELS,
 ]
 
 /**


### PR DESCRIPTION
## Summary

Adds two new model-ID prefixes that bypass OpenRouter for users who want native billing or models the OpenRouter catalogue doesn't proxy:

- `dashscope/...` → Alibaba DashScope (Qwen Max / Plus / Turbo, Qwen3 Coder Plus, Qwen-VL Max). Requires `DASHSCOPE_API_KEY`.
- `huggingface/owner/repo` → HuggingFace Inference Providers router (Llama 3.3 70B, Qwen2.5 72B, DeepSeek V3, Mistral Nemo, anything chat-capable on the HF Router). Requires `HUGGINGFACE_API_KEY`.

Both endpoints speak OpenAI-compatible mode, so they're wired through `createOpenAI({ baseURL })` rather than dedicated SDK packages — **no new dependencies**. The new branches sit before the generic `provider/model → OpenRouter` fallback in `resolveModel`, and the `huggingface/owner/repo` shape works because we strip only the `huggingface/` prefix and forward the rest verbatim.

## Why

The existing `qwen/qwen3.6-plus` only routes through OpenRouter. Users who already have a DashScope account (cheaper for Qwen-only workloads, native Chinese-region support) had no way to use it. HuggingFace Inference Providers similarly unlocks the long tail of open models that OpenRouter doesn't carry, all behind one OpenAI-compatible endpoint. Mirrors the existing direct-fallback pattern used for Anthropic / OpenAI / Google.

## Files changed

- `src/server/lib/ai/providers.ts` — `DASHSCOPE_API_KEY` + `HUGGINGFACE_API_KEY` added to `ProviderEnv`, two new branches in `resolveModel`, both reported by `getAvailableProviders`.
- `src/server/index.ts` — env vars added to the worker `Env` interface.
- `src/shared/config/models.ts` — `DASHSCOPE_MODELS` + `HUGGINGFACE_MODELS` arrays, included in `ENABLED_MODEL_IDS`. Header doc updated with the new prefixes.
- `.dev.vars.example` — new "AI Provider API Keys" section documents every key (Anthropic, OpenAI, Google, DashScope, HuggingFace, OpenRouter) with sign-up URLs.
- `CLAUDE.md` — AI Module table extended with the new direct routes plus a hint for adding more OpenAI-compatible providers (Together, Groq, Fireworks, Cerebras).

## Test plan

- [x] `pnpm type-check` clean
- [ ] Set `DASHSCOPE_API_KEY` in `.dev.vars`, pick `dashscope/qwen3.6-max` in the chat selector, send a message, confirm streaming works
- [ ] Set `HUGGINGFACE_API_KEY` in `.dev.vars`, pick `huggingface/meta-llama/Llama-3.3-70B-Instruct`, send a message, confirm streaming works
- [ ] Confirm `qwen/qwen3.6-plus` (OpenRouter route) still works — i.e. the new prefix branches don't accidentally swallow the generic provider/model rule
- [ ] Confirm a missing-key request returns a useful error (e.g. picking `dashscope/...` without `DASHSCOPE_API_KEY` set)

https://claude.ai/code/session_01M38e98qnojB4JePFGtrQxt

---
_Generated by [Claude Code](https://claude.ai/code/session_01M38e98qnojB4JePFGtrQxt)_