### PR TITLE
feat(ux): tighten empty-state FTUE across every feature surface

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -7,7 +7,9 @@ import { createErrorHandler } from './lib/error-reporting'
 import { ProtectedRoute } from './components/shared/ProtectedRoute'
 import { PublicOnlyRoute } from './components/shared/PublicOnlyRoute'
 import { ThemeURLHandler } from './components/ThemeURLHandler'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Mic, Camera } from 'lucide-react'
+import { features } from '@/shared/config/features'
+import { EmptyState } from './components/EmptyState'
 
 // Critical-path imports (always in the main bundle)
 import { LandingPage } from './pages/LandingPage'
@@ -46,6 +48,39 @@ function PageSpinner() {
   return (
     <div className="flex h-64 items-center justify-center">
       <Loader2 className="size-6 animate-spin text-muted-foreground" />
+    </div>
+  )
+}
+
+/**
+ * Renders the page when the feature is enabled; otherwise renders a
+ * gentle "this feature is opt-in" empty state. Stops bookmarked links
+ * to disabled features from looking like a 404.
+ */
+function FeatureGatedPage({
+  enabled,
+  icon,
+  title,
+  description,
+  envVar,
+  children,
+}: {
+  enabled: boolean
+  icon: typeof Mic
+  title: string
+  description: string
+  envVar: string
+  children: React.ReactNode
+}) {
+  if (enabled) return <>{children}</>
+  return (
+    <div className="container mx-auto py-12">
+      <EmptyState
+        icon={icon}
+        title={title}
+        description={description}
+        tips={[`Set ${envVar}=true in your .dev.vars (or production env) and reload.`]}
+      />
     </div>
   )
 }
@@ -135,15 +170,40 @@ function App() {
             <Route path="connectors" element={<ConnectorsPage />} />
 
             {/* Voice agent reference — @cloudflare/voice + agents SDK.
-                Gated behind `voiceAgent` feature flag (default OFF); the
-                scaffold is always compiled but the route only resolves
-                if a user navigates there manually. */}
-            <Route path="voice-example" element={<VoiceInputExamplePage />} />
+                Gated behind `voiceAgent` feature flag (default OFF). When
+                disabled, the route still resolves but renders a friendly
+                "opt-in" page so bookmarks don't 404. */}
+            <Route
+              path="voice-example"
+              element={
+                <FeatureGatedPage
+                  enabled={features.voiceAgent}
+                  icon={Mic}
+                  title="Voice agent is opt-in"
+                  description="The voice example streams microphone audio to a Durable Object for live transcription. It ships disabled by default — turn it on with a feature flag."
+                  envVar="VITE_FEATURE_VOICE_AGENT"
+                >
+                  <VoiceInputExamplePage />
+                </FeatureGatedPage>
+              }
+            />
 
             {/* Video agent reference — sampled frames → WS → Durable Object
-                → Workers AI vision model. No Cloudflare Realtime SFU needed
-                for the sampled pattern. Gated behind `videoAgent` flag. */}
-            <Route path="video-example" element={<VideoInputExamplePage />} />
+                → Workers AI vision model. Same opt-in pattern as voice. */}
+            <Route
+              path="video-example"
+              element={
+                <FeatureGatedPage
+                  enabled={features.videoAgent}
+                  icon={Camera}
+                  title="Video agent is opt-in"
+                  description="The video example samples webcam frames and sends them to a vision model for live captions. It ships disabled by default — turn it on with a feature flag."
+                  envVar="VITE_FEATURE_VIDEO_AGENT"
+                >
+                  <VideoInputExamplePage />
+                </FeatureGatedPage>
+              }
+            />
 
             {/* Profile redirects to Settings (Profile tab is default) */}
             <Route path="profile" element={<Navigate to="/dashboard/settings" replace />} />

--- a/src/client/components/EmptyState.tsx
+++ b/src/client/components/EmptyState.tsx
@@ -11,6 +11,15 @@
  *   description="Create your first document to get started."
  *   action={{ label: "Create Document", onClick: () => navigate('/new') }}
  * />
+ *
+ * @example with tips
+ * <EmptyState
+ *   icon={Zap}
+ *   title="No skills yet"
+ *   description="Skills are reusable agent procedures."
+ *   tips={["Type /skill-name in chat to invoke one", "Install from GitHub or upload a SKILL.md"]}
+ *   action={{ label: "Add skill", onClick: () => {} }}
+ * />
  */
 import type { LucideIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -25,6 +34,12 @@ interface EmptyStateProps {
   icon: LucideIcon
   title: string
   description?: string
+  /**
+   * Up to 3 short tips rendered as a bulleted list above the actions.
+   * Use to explain *how* the user gets data into this view when the
+   * description alone isn't enough (e.g. "type /skill-name in chat").
+   */
+  tips?: string[]
   action?: EmptyStateAction
   secondaryAction?: EmptyStateAction
   className?: string
@@ -34,6 +49,7 @@ export function EmptyState({
   icon: Icon,
   title,
   description,
+  tips,
   action,
   secondaryAction,
   className,
@@ -41,11 +57,21 @@ export function EmptyState({
   return (
     <div className={`flex flex-col items-center justify-center py-16 px-4 text-center ${className ?? ''}`}>
       <div className="rounded-full bg-muted p-4 mb-4">
-        <Icon className="h-8 w-8 text-muted-foreground" />
+        <Icon className="h-8 w-8 text-muted-foreground" aria-hidden="true" />
       </div>
       <h3 className="text-lg font-medium mb-1">{title}</h3>
       {description && (
-        <p className="text-sm text-muted-foreground max-w-sm mb-6">{description}</p>
+        <p className="text-sm text-muted-foreground max-w-sm mb-4">{description}</p>
+      )}
+      {tips && tips.length > 0 && (
+        <ul className="mb-6 max-w-sm space-y-1 text-left text-sm text-muted-foreground">
+          {tips.slice(0, 3).map((tip) => (
+            <li key={tip} className="flex gap-2">
+              <span aria-hidden="true" className="mt-1 block h-1 w-1 shrink-0 rounded-full bg-muted-foreground/60" />
+              <span>{tip}</span>
+            </li>
+          ))}
+        </ul>
       )}
       {(action || secondaryAction) && (
         <div className="flex items-center gap-3">

--- a/src/client/modules/activity/pages/ActivityPage.tsx
+++ b/src/client/modules/activity/pages/ActivityPage.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { useActivities, useActivityStats, type Activity } from '../hooks/useActivity'
+import { EmptyState } from '@/client/components/EmptyState'
 import {
   Activity as ActivityIcon,
   Plus,
@@ -215,13 +216,15 @@ export function ActivityPage() {
               ))}
             </div>
           ) : activities.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12 text-center">
-              <ActivityIcon className="h-12 w-12 text-muted-foreground/50" />
-              <p className="mt-4 text-lg font-medium">No Activity Yet</p>
-              <p className="text-sm text-muted-foreground">
-                Your actions will appear here as you use the application.
-              </p>
-            </div>
+            <EmptyState
+              icon={ActivityIcon}
+              title={actionFilter !== 'all' ? `No ${actionFilter} actions yet` : 'No activity yet'}
+              description={
+                actionFilter !== 'all'
+                  ? 'Try a different filter, or come back after using the app.'
+                  : 'Creating, editing, or deleting anything in the app will show up here as an audit trail.'
+              }
+            />
           ) : (
             <div className="space-y-4">
               {activities.map((activity) => (

--- a/src/client/modules/admin/components/UsersTabContent.tsx
+++ b/src/client/modules/admin/components/UsersTabContent.tsx
@@ -21,6 +21,7 @@ import { useUsers } from '../hooks/useAdmin'
 import { UserList } from './UserList'
 import { Search, ChevronLeft, ChevronRight, Users } from 'lucide-react'
 import { useDebounce } from '@/client/hooks/useDebounce'
+import { EmptyState } from '@/client/components/EmptyState'
 
 const SORT_OPTIONS = [
   { value: 'createdAt:desc', label: 'Newest first' },
@@ -140,9 +141,15 @@ export function UsersTabContent() {
             Failed to load users. Please try again.
           </div>
         ) : data?.users.length === 0 ? (
-          <div className="py-8 text-center text-muted-foreground">
-            {debouncedSearch ? 'No users match your search.' : 'No users found.'}
-          </div>
+          <EmptyState
+            icon={Users}
+            title={debouncedSearch ? 'No matching users' : 'No users yet'}
+            description={
+              debouncedSearch
+                ? `Nothing matches "${debouncedSearch}". Try a different name or email.`
+                : 'Once people sign in, you’ll be able to manage their roles and access here.'
+            }
+          />
         ) : (
           <UserList users={data?.users || []} />
         )}

--- a/src/client/modules/approvals/pages/ApprovalsPage.tsx
+++ b/src/client/modules/approvals/pages/ApprovalsPage.tsx
@@ -12,7 +12,7 @@
  * notification toast). ?status=all shows resolved approvals too.
  */
 import { useMemo, useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -64,6 +64,7 @@ type Filter = 'pending' | 'all'
 
 export function ApprovalsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
   const filter: Filter = searchParams.get('status') === 'all' ? 'all' : 'pending'
   const focus = searchParams.get('focus')
 
@@ -116,8 +117,21 @@ export function ApprovalsPage() {
           title={filter === 'pending' ? 'No pending approvals' : 'No approvals yet'}
           description={
             filter === 'pending'
-              ? 'When an autonomous agent wants to take a destructive action (send email, post message), it queues here for your review.'
+              ? "Nothing to review. When the AI proposes a destructive action (sending an email, posting a message, saving a memory), it'll queue here first."
               : 'Resolved approvals will appear here once agents start queuing actions.'
+          }
+          tips={
+            filter === 'pending'
+              ? [
+                  'Ask the AI in chat to draft and send an email',
+                  'Memory updates the AI proposes also land here',
+                ]
+              : undefined
+          }
+          action={
+            filter === 'pending'
+              ? { label: 'Open chat', onClick: () => navigate('/dashboard/chat') }
+              : undefined
           }
         />
       )}

--- a/src/client/modules/chat/components/ArtifactSidebar.tsx
+++ b/src/client/modules/chat/components/ArtifactSidebar.tsx
@@ -232,8 +232,11 @@ export function ArtifactSidebar({ messages, onClose, scrollRoot: _scrollRoot }: 
 
       <div className="flex-1 min-h-0 overflow-y-auto px-2 py-2 space-y-4">
         {!hasAny && (
-          <div className="px-2 py-8 text-xs text-muted-foreground text-center">
-            No artifacts or files yet. Ask the AI for a chart, dashboard, diagram, or drop a file into the chat.
+          <div className="px-2 py-8 text-xs text-muted-foreground text-center space-y-2">
+            <p className="font-medium text-foreground/80">Nothing here yet</p>
+            <p>
+              Ask the AI for a chart, dashboard, or diagram — or drop a file into the chat. Both show up in this panel.
+            </p>
           </div>
         )}
 

--- a/src/client/modules/chat/pages/ArtifactsPage.tsx
+++ b/src/client/modules/chat/pages/ArtifactsPage.tsx
@@ -11,12 +11,13 @@
  * could add a per-artifact preview pane.
  */
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Sparkles, Search, MessageSquare, Code2, Image as ImageIcon, GitBranch, Loader2 } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { apiClient } from '@/client/lib/api-client'
 import { cn } from '@/lib/utils'
+import { EmptyState as SharedEmptyState } from '@/client/components/EmptyState'
 
 interface Artifact {
   conversationId: string
@@ -153,6 +154,7 @@ export function ArtifactsPage() {
 }
 
 function EmptyState({ search, typeFilter }: { search: string; typeFilter: string }) {
+  const navigate = useNavigate()
   if (search || typeFilter !== 'all') {
     return (
       <div className="rounded-lg border border-dashed border-border px-6 py-12 text-center">
@@ -161,13 +163,16 @@ function EmptyState({ search, typeFilter }: { search: string; typeFilter: string
     )
   }
   return (
-    <div className="rounded-lg border border-dashed border-border px-6 py-16 text-center space-y-3">
-      <Sparkles className="size-10 mx-auto text-muted-foreground" />
-      <h3 className="font-semibold">No artifacts yet</h3>
-      <p className="text-sm text-muted-foreground max-w-md mx-auto">
-        Ask the AI to create an HTML page, SVG illustration, or Mermaid diagram in any chat — they'll appear here.
-      </p>
-    </div>
+    <SharedEmptyState
+      icon={Sparkles}
+      title="No artifacts yet"
+      description="The AI can build interactive HTML pages, SVG illustrations, and Mermaid diagrams right inside a chat."
+      tips={[
+        'Try: "Make me a Mermaid diagram of our auth flow"',
+        'Try: "Build an SVG icon for a coffee cup"',
+      ]}
+      action={{ label: 'Open chat', onClick: () => navigate('/dashboard/chat') }}
+    />
   )
 }
 

--- a/src/client/modules/chat/pages/ChatPage.tsx
+++ b/src/client/modules/chat/pages/ChatPage.tsx
@@ -128,10 +128,16 @@ export function ChatPage() {
   // loads so the server, not the UI, has the final say.
   const { data: modelsData } = useQuery({
     queryKey: ['ai-models'],
-    queryFn: () => apiClient.get<{ models: Array<{ id: string; supportsVision: boolean }>; recommended: string }>('/api/ai/models'),
+    queryFn: () => apiClient.get<{ models: Array<{ id: string; supportsVision: boolean; route?: string }>; recommended: string }>('/api/ai/models'),
     staleTime: 5 * 60 * 1000,
   })
-  const supportsVision = modelsData?.models.find((m) => m.id === model)?.supportsVision ?? true
+  const selectedModelInfo = modelsData?.models.find((m) => m.id === model)
+  const supportsVision = selectedModelInfo?.supportsVision ?? true
+  // The model selector tags an unroutable model with `route: 'unknown'` —
+  // it means the operator hasn't configured the API key for the provider.
+  // Surface this in the chat welcome state so the user doesn't fire off a
+  // first message and get a routing error mid-stream.
+  const selectedModelMissingKey = selectedModelInfo?.route === 'unknown'
   // Accept is "everything" for vision-capable models, or "everything minus images"
   // for text-only models. Drop, paste, and the + menu all respect this.
   const acceptString = supportsVision
@@ -970,6 +976,8 @@ export function ChatPage() {
                   userEmail={session?.user?.email}
                   onPresetPick={handlePresetPick}
                   onPresetPreview={handlePresetPreview}
+                  modelMissingKey={selectedModelMissingKey}
+                  modelName={selectedModelInfo?.id}
                 />
               </div>
             </div>
@@ -1152,11 +1160,15 @@ function EmptyStateBody({
   userEmail,
   onPresetPick,
   onPresetPreview,
+  modelMissingKey,
+  modelName,
 }: {
   userName?: string
   userEmail?: string
   onPresetPick: (text: string) => void
   onPresetPreview: (text: string | null) => void
+  modelMissingKey?: boolean
+  modelName?: string
 }) {
   return (
     <>
@@ -1171,6 +1183,16 @@ function EmptyStateBody({
       <p className="text-sm text-muted-foreground/60 -mt-3">
         Ask anything, drop a file, or pick a starter below.
       </p>
+      {modelMissingKey && (
+        <div className="mx-auto max-w-xl rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-left text-xs text-amber-900 dark:text-amber-200">
+          <div className="font-medium">
+            {modelName ? `${modelName} ` : 'This model '}needs an API key to send messages.
+          </div>
+          <p className="mt-0.5 text-amber-800/90 dark:text-amber-200/80">
+            Pick a free Workers AI model from the dropdown below, or ask the operator to set the provider's API key.
+          </p>
+        </div>
+      )}
       <ActionChips onPick={onPresetPick} onPreview={onPresetPreview} />
       <ExampleQuestions onPick={onPresetPick} />
     </>

--- a/src/client/modules/files/components/FileList.tsx
+++ b/src/client/modules/files/components/FileList.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/client/components/EmptyState'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -54,6 +55,12 @@ interface FileListProps {
    * folder, the empty state clarifies the filter is narrowing the view.
    */
   folder?: string
+  /**
+   * If set, the empty state shows an "Upload file" CTA that calls this.
+   * Wire it to the same dialog opener used by the page-header upload
+   * button so the user can act without scrolling back to the header.
+   */
+  onUploadClick?: () => void
 }
 
 const iconMap = {
@@ -64,7 +71,7 @@ const iconMap = {
   file: FileIcon,
 }
 
-export function FileList({ files, isLoading, folder }: FileListProps) {
+export function FileList({ files, isLoading, folder, onUploadClick }: FileListProps) {
   const [deleteTarget, setDeleteTarget] = useState<FileItem | null>(null)
   const [editTarget, setEditTarget] = useState<FileItem | null>(null)
   const [editName, setEditName] = useState('')
@@ -145,17 +152,20 @@ export function FileList({ files, isLoading, folder }: FileListProps) {
     const isFiltered = !!folder && folder !== 'all'
     const folderLabel = folder === '/' ? 'the root folder' : `"${folder}"`
     return (
-      <div className="text-center py-12 text-muted-foreground">
-        <FileIcon className="mx-auto h-12 w-12 mb-4 opacity-50" />
-        <p className="text-lg font-medium">
-          {isFiltered ? `No files in ${folderLabel}` : 'No files yet'}
-        </p>
-        <p className="text-sm">
-          {isFiltered
+      <EmptyState
+        icon={FileIcon}
+        title={isFiltered ? `No files in ${folderLabel}` : 'No files yet'}
+        description={
+          isFiltered
             ? 'Try a different folder, or upload a file here.'
-            : 'Upload your first file to get started.'}
-        </p>
-      </div>
+            : 'Drop a PDF, image, doc, or zip — uploads are private by default and can be shared via link.'
+        }
+        action={
+          onUploadClick
+            ? { label: 'Upload file', onClick: onUploadClick }
+            : undefined
+        }
+      />
     )
   }
 

--- a/src/client/modules/files/pages/FilesPage.tsx
+++ b/src/client/modules/files/pages/FilesPage.tsx
@@ -129,7 +129,12 @@ export function FilesPage() {
           </div>
         </CardHeader>
         <CardContent>
-          <FileList files={files} isLoading={isLoading} folder={currentFolder} />
+          <FileList
+            files={files}
+            isLoading={isLoading}
+            folder={currentFolder}
+            onUploadClick={() => setUploadOpen(true)}
+          />
         </CardContent>
       </Card>
     </div>

--- a/src/client/modules/projects/pages/ProjectsIndexPage.tsx
+++ b/src/client/modules/projects/pages/ProjectsIndexPage.tsx
@@ -20,6 +20,7 @@ import { useProjectList, useStarProject, type Project } from '../hooks/useProjec
 import { CreateProjectModal } from '../components/CreateProjectModal'
 import { PROJECT_COLOR_CLASSES, isProjectColor } from '../colors'
 import { cn } from '@/lib/utils'
+import { EmptyState as SharedEmptyState } from '@/client/components/EmptyState'
 
 type SortKey = 'activity' | 'name' | 'created'
 
@@ -146,17 +147,12 @@ function EmptyState({ search, showArchived, onCreate }: { search: string; showAr
     )
   }
   return (
-    <div className="rounded-lg border border-dashed border-border px-6 py-16 text-center space-y-3">
-      <FolderOpen className="size-10 mx-auto text-muted-foreground" />
-      <h3 className="font-semibold">No projects yet</h3>
-      <p className="text-sm text-muted-foreground max-w-md mx-auto">
-        Create your first project to organise chats with persistent memory, instructions, and files.
-      </p>
-      <Button onClick={onCreate}>
-        <Plus className="size-4 mr-1.5" />
-        New project
-      </Button>
-    </div>
+    <SharedEmptyState
+      icon={FolderOpen}
+      title="No projects yet"
+      description="Projects bundle a set of chats with shared memory, instructions, and files — handy for ongoing work like a side product, a customer, or a research thread."
+      action={{ label: 'New project', onClick: onCreate }}
+    />
   )
 }
 

--- a/src/client/modules/settings/components/ApiTokensSection.tsx
+++ b/src/client/modules/settings/components/ApiTokensSection.tsx
@@ -15,6 +15,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { ConfirmDialog, useConfirmDialog } from '@/components/ui/confirm-dialog'
+import { EmptyState } from '@/client/components/EmptyState'
 import { appConfig } from '@/shared/config/app'
 import {
   Dialog,
@@ -392,13 +393,12 @@ export function ApiTokensSection() {
               </TableBody>
             </Table>
           ) : (
-            <div className="text-center py-8 text-muted-foreground">
-              <Key className="h-12 w-12 mx-auto mb-4 opacity-50" />
-              <p>No API tokens created yet</p>
-              <p className="text-sm mt-1">
-                Create a token to allow external services to access your data
-              </p>
-            </div>
+            <EmptyState
+              icon={Key}
+              title="No API tokens yet"
+              description="Tokens let external services (ElevenLabs, n8n, your own scripts) call this app on your behalf with scoped permissions."
+              action={{ label: 'Create token', onClick: () => setShowCreateDialog(true) }}
+            />
           )}
         </CardContent>
       </Card>

--- a/src/client/modules/skills/pages/SkillsPage.tsx
+++ b/src/client/modules/skills/pages/SkillsPage.tsx
@@ -20,6 +20,8 @@ import {
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { EmptyState } from '@/client/components/EmptyState'
+import { Zap } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -153,24 +155,21 @@ export function SkillsPage() {
         </div>
       ) : skills.length === 0 ? (
         <Card>
-          <CardContent className="space-y-4 py-12 text-center">
-            <div>
-              <p className="text-muted-foreground">No skills yet.</p>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Install one from GitHub or upload a SKILL.md / zip to get
-                started.
-              </p>
-            </div>
-            <div className="flex items-center justify-center gap-2">
-              <Button onClick={() => setUploadOpen(true)}>
-                <Upload className="mr-2 h-4 w-4" />
-                Add skill
-              </Button>
-              <Button variant="outline" onClick={() => setInstallOpen(true)}>
-                <GithubIcon className="mr-2 h-4 w-4" />
-                Install from GitHub
-              </Button>
-            </div>
+          <CardContent className="py-2">
+            <EmptyState
+              icon={Zap}
+              title="No skills yet"
+              description="Skills are reusable agent procedures the AI can invoke during chat."
+              tips={[
+                'Type /skill-name in any chat to activate a skill',
+                'Install bundled examples from GitHub, or paste your own SKILL.md',
+              ]}
+              action={{ label: 'Add skill', onClick: () => setUploadOpen(true) }}
+              secondaryAction={{
+                label: 'Install from GitHub',
+                onClick: () => setInstallOpen(true),
+              }}
+            />
           </CardContent>
         </Card>
       ) : (


### PR DESCRIPTION
## Summary

Reviewed every feature's first-time user experience from a new user's
perspective and tightened the empty-state pattern so people don't need
to read docs to understand what each page is for or what to do next.

## Audit findings

Every empty pane was inventoried. Findings (and fixes) by feature:

| Feature | Before | After |
|---|---|---|
| **Files** | "Upload your first file to get started" with no inline CTA | Inline "Upload file" CTA opens the same dialog as the header button |
| **Activity** | "No Activity Yet" / "Your actions will appear here…" — vague | Explains what gets logged: "Creating, editing, or deleting anything in the app will show up here as an audit trail." |
| **Skills** | "No skills yet" + Add/Install — didn't explain *what* a skill is | Migrated to primitive with tips: "Type /skill-name in any chat to activate" |
| **API Tokens** | Inline "Create a token to allow external services to access your data" with no CTA | Inline CTA + concrete examples (ElevenLabs, n8n, scripts) |
| **Admin Users** | Bare "No users found." | Icon + sentence per state (search vs first-run) |
| **Artifacts** | "No artifacts yet" — no path to creating one | Tips with sample prompts + "Open chat" CTA |
| **Projects** | "Create your first project to organise chats…" | Slightly better copy: "Projects bundle a set of chats with shared memory, instructions, and files — handy for ongoing work like a side product, a customer, or a research thread." |
| **Approvals** | "When an autonomous agent wants…" — passive, no path forward | Names the realistic trigger ("Ask the AI in chat to draft and send an email") + "Open chat" CTA |
| **Chat welcome** | No warning when selected model has no API key — user discovered on first send | Inline amber banner: "$model needs an API key. Pick a free Workers AI model from the dropdown below, or ask the operator to set the provider's API key." |
| **Voice / Video** | Bookmarked routes worked even when feature flag was off, hiding the requirement | Friendly opt-in page: "Set VITE_FEATURE_X_AGENT=true in your .dev.vars and reload." |

## Primitive change

`src/client/components/EmptyState.tsx` gains an optional `tips` slot
(up to 3 short bullets above the actions) for surfaces where users
need a one-line nudge on *how* to make data appear (Skills, Approvals).
All existing call sites are unaffected — additive prop.

## Test plan

- [x] `pnpm type-check` passes
- [ ] Manual: sign in as a new user with empty data, walk every nav
  item, confirm each empty pane answers "what is this?" and "what do
  I do next?" in <3 seconds
- [ ] Manual: configure a model whose key is unset, open chat, confirm
  the amber no-key banner appears in the welcome state
- [ ] Manual: navigate to `/dashboard/voice-example` with
  `VITE_FEATURE_VOICE_AGENT=false`, confirm gated empty state renders

https://claude.ai/code/session_01UYJoAGM6veougm65vJydkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYJoAGM6veougm65vJydkw)_