### PR TITLE
fix(auth): route all createAuth call sites through createAuthFromEnv

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@ import { logger } from 'hono/logger'
 import { zValidator } from '@hono/zod-validator'
 import { z } from 'zod'
 import type { D1Database } from '@cloudflare/workers-types'
-import { createAuth } from './modules/auth'
+import { createAuthFromEnv } from './modules/auth'
 import settingsRoutes from './modules/settings/routes'
 import onboardingRoutes from './modules/onboarding/routes'
 import sessionsRoutes from './modules/settings/sessions'
@@ -253,17 +253,7 @@ app.get('/api/auth/config', async (c) => {
 
 // Auth routes (better-auth handles all /api/auth/* routes)
 app.all('/api/auth/*', async (c) => {
-  const auth = createAuth(c.env.DB, {
-    BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
-    BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
-    GOOGLE_CLIENT_ID: c.env.GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET: c.env.GOOGLE_CLIENT_SECRET,
-    EMAIL_API_KEY: c.env.EMAIL_API_KEY,
-    EMAIL_FROM: c.env.EMAIL_FROM,
-    ENABLE_EMAIL_LOGIN: c.env.ENABLE_EMAIL_LOGIN,
-    ENABLE_EMAIL_SIGNUP: c.env.ENABLE_EMAIL_SIGNUP,
-    TRUSTED_ORIGINS: c.env.TRUSTED_ORIGINS,
-  })
+  const auth = createAuthFromEnv(c.env.DB, c.env as unknown as Record<string, unknown>)
   return auth.handler(c.req.raw)
 })
 
@@ -513,17 +503,7 @@ type RequestSession = {
 
 async function getRequestSession(env: Env, headers: Headers): Promise<RequestSession | null> {
   try {
-    const auth = createAuth(env.DB, {
-      BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
-      BETTER_AUTH_URL: env.BETTER_AUTH_URL,
-      GOOGLE_CLIENT_ID: env.GOOGLE_CLIENT_ID,
-      GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET,
-      EMAIL_API_KEY: env.EMAIL_API_KEY,
-      EMAIL_FROM: env.EMAIL_FROM,
-      ENABLE_EMAIL_LOGIN: env.ENABLE_EMAIL_LOGIN,
-      ENABLE_EMAIL_SIGNUP: env.ENABLE_EMAIL_SIGNUP,
-      TRUSTED_ORIGINS: env.TRUSTED_ORIGINS,
-    })
+    const auth = createAuthFromEnv(env.DB, env as unknown as Record<string, unknown>)
     const session = await auth.api.getSession({ headers })
     const userId = session?.user?.id
     if (!userId) return null

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -2,7 +2,7 @@ import { createMiddleware } from 'hono/factory'
 import { drizzle } from 'drizzle-orm/d1'
 import { eq } from 'drizzle-orm'
 import type { Env } from '../index'
-import { createAuth } from '../modules/auth'
+import { createAuthFromEnv } from '../modules/auth'
 import * as schema from '@/server/db/schema'
 import type { ApiTokenScope } from '@/shared/config/scopes'
 
@@ -204,14 +204,7 @@ export const authMiddleware = createMiddleware<AuthContext>(async (c, next) => {
     }
 
     // Fall back to session authentication (cookies)
-    const auth = createAuth(c.env.DB, {
-      BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
-      BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
-      GOOGLE_CLIENT_ID: c.env.GOOGLE_CLIENT_ID,
-      GOOGLE_CLIENT_SECRET: c.env.GOOGLE_CLIENT_SECRET,
-      EMAIL_API_KEY: c.env.EMAIL_API_KEY,
-      EMAIL_FROM: c.env.EMAIL_FROM,
-    })
+    const auth = createAuthFromEnv(c.env.DB, c.env as unknown as Record<string, unknown>)
 
     // Get session from better-auth using the raw request
     const session = await auth.api.getSession({

--- a/src/server/middleware/optional-auth.ts
+++ b/src/server/middleware/optional-auth.ts
@@ -18,7 +18,7 @@
  */
 import { createMiddleware } from 'hono/factory'
 import type { Env } from '../index'
-import { createAuth } from '../modules/auth'
+import { createAuthFromEnv } from '../modules/auth'
 
 export type OptionalAuthContext = {
   Bindings: Env
@@ -37,13 +37,7 @@ export type OptionalAuthContext = {
 
 export const optionalAuthMiddleware = createMiddleware<OptionalAuthContext>(async (c, next) => {
   try {
-    const auth = createAuth(c.env.DB, {
-      BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
-      BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
-      GOOGLE_CLIENT_ID: c.env.GOOGLE_CLIENT_ID,
-      GOOGLE_CLIENT_SECRET: c.env.GOOGLE_CLIENT_SECRET,
-      TRUSTED_ORIGINS: c.env.TRUSTED_ORIGINS,
-    })
+    const auth = createAuthFromEnv(c.env.DB, c.env as unknown as Record<string, unknown>)
 
     const session = await auth.api.getSession({ headers: c.req.raw.headers })
 

--- a/src/server/middleware/owner.ts
+++ b/src/server/middleware/owner.ts
@@ -36,7 +36,7 @@
 import { createMiddleware } from 'hono/factory'
 import { getCookie, setCookie } from 'hono/cookie'
 import type { Env } from '../index'
-import { createAuth } from '../modules/auth'
+import { createAuthFromEnv } from '../modules/auth'
 
 /** Cookie name. Prefix with your app's token prefix or change to
  *  whatever signals "this is our session" to your CDN logs. */
@@ -60,10 +60,7 @@ export const ownerMiddleware = createMiddleware<OwnerContext>(async (c, next) =>
   // catching keeps the guest path working in that case.
   let userId: string | undefined
   try {
-    const auth = createAuth(c.env.DB, {
-      BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
-      BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
-    })
+    const auth = createAuthFromEnv(c.env.DB, c.env as unknown as Record<string, unknown>)
     const session = await auth.api.getSession({ headers: c.req.raw.headers })
     if (session?.user?.id) userId = session.user.id
   } catch {

--- a/src/server/modules/settings/routes.ts
+++ b/src/server/modules/settings/routes.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator'
 import { drizzle } from 'drizzle-orm/d1'
 import { eq } from 'drizzle-orm'
 import { authMiddleware, requireScopes, type AuthContext } from '@/server/middleware/auth'
-import { createAuth } from '@/server/modules/auth'
+import { createAuthFromEnv } from '@/server/modules/auth'
 import * as schema from '@/server/db/schema'
 import {
   updateNameSchema,
@@ -52,14 +52,7 @@ app.patch(
 
     try {
       // Create auth instance
-      const auth = createAuth(c.env.DB, {
-        BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
-        BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
-        GOOGLE_CLIENT_ID: c.env.GOOGLE_CLIENT_ID,
-        GOOGLE_CLIENT_SECRET: c.env.GOOGLE_CLIENT_SECRET,
-        EMAIL_API_KEY: c.env.EMAIL_API_KEY,
-        EMAIL_FROM: c.env.EMAIL_FROM,
-      })
+      const auth = createAuthFromEnv(c.env.DB, c.env as unknown as Record<string, unknown>)
 
       // Use better-auth's updateUser API
       const result = await auth.api.updateUser({
@@ -311,14 +304,7 @@ app.post('/email', requireSessionAuth, zValidator('json', changeEmailSchema), as
 
   try {
     // Create auth instance
-    const auth = createAuth(c.env.DB, {
-      BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
-      BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
-      GOOGLE_CLIENT_ID: c.env.GOOGLE_CLIENT_ID,
-      GOOGLE_CLIENT_SECRET: c.env.GOOGLE_CLIENT_SECRET,
-      EMAIL_API_KEY: c.env.EMAIL_API_KEY,
-      EMAIL_FROM: c.env.EMAIL_FROM,
-    })
+    const auth = createAuthFromEnv(c.env.DB, c.env as unknown as Record<string, unknown>)
 
     // Use better-auth's changeEmail API
     // This triggers sendChangeEmailVerification callback
@@ -391,12 +377,7 @@ app.post('/password', requireSessionAuth, zValidator('json', changePasswordSchem
 
     // Use better-auth's changePassword API
     // This handles password verification and hashing using the correct salt:hash format
-    const auth = createAuth(c.env.DB, {
-      BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
-      BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
-      GOOGLE_CLIENT_ID: c.env.GOOGLE_CLIENT_ID,
-      GOOGLE_CLIENT_SECRET: c.env.GOOGLE_CLIENT_SECRET,
-    })
+    const auth = createAuthFromEnv(c.env.DB, c.env as unknown as Record<string, unknown>)
 
     const result = await auth.api.changePassword({
       body: {
@@ -443,14 +424,7 @@ app.delete('/account', requireSessionAuth, zValidator('json', deleteAccountSchem
 
   try {
     // Create auth instance
-    const auth = createAuth(c.env.DB, {
-      BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
-      BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
-      GOOGLE_CLIENT_ID: c.env.GOOGLE_CLIENT_ID,
-      GOOGLE_CLIENT_SECRET: c.env.GOOGLE_CLIENT_SECRET,
-      EMAIL_API_KEY: c.env.EMAIL_API_KEY,
-      EMAIL_FROM: c.env.EMAIL_FROM,
-    })
+    const auth = createAuthFromEnv(c.env.DB, c.env as unknown as Record<string, unknown>)
 
     // For email/password users: require password verification
     // For OAuth users: will require email verification

--- a/src/server/modules/settings/sessions.ts
+++ b/src/server/modules/settings/sessions.ts
@@ -3,7 +3,7 @@ import { drizzle } from 'drizzle-orm/d1'
 import { eq, ne, and, desc, isNull } from 'drizzle-orm'
 import { UAParser } from 'ua-parser-js'
 import { authMiddleware, type AuthContext } from '@/server/middleware/auth'
-import { createAuth } from '@/server/modules/auth'
+import { createAuthFromEnv } from '@/server/modules/auth'
 import * as schema from '@/server/db/schema'
 
 const app = new Hono<AuthContext>()
@@ -19,14 +19,7 @@ app.use('/*', authMiddleware)
  * object and use its session id instead — reliable on any deployment.
  */
 async function getCurrentSessionId(c: any): Promise<string | null> {
-  const auth = createAuth(c.env.DB, {
-    BETTER_AUTH_SECRET: c.env.BETTER_AUTH_SECRET,
-    BETTER_AUTH_URL: c.env.BETTER_AUTH_URL,
-    GOOGLE_CLIENT_ID: c.env.GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET: c.env.GOOGLE_CLIENT_SECRET,
-    EMAIL_API_KEY: c.env.EMAIL_API_KEY,
-    EMAIL_FROM: c.env.EMAIL_FROM,
-  })
+  const auth = createAuthFromEnv(c.env.DB, c.env as unknown as Record<string, unknown>)
   const session = await auth.api.getSession({ headers: c.req.raw.headers })
   return session?.session?.id ?? null
 }

--- a/src/server/modules/spaces/space-agent.ts
+++ b/src/server/modules/spaces/space-agent.ts
@@ -34,7 +34,7 @@ import {
   conversationMessages,
   conversations,
 } from '@/server/modules/conversations/db/schema'
-import { createAuth } from '@/server/modules/auth'
+import { createAuthFromEnv } from '@/server/modules/auth'
 
 interface SpaceConnectionState {
   userId: string
@@ -193,14 +193,7 @@ export class SpaceAgent extends Agent<any, Record<string, never>> {
     ctx: ConnectionContext
   ): Promise<string | null> {
     try {
-      const auth = createAuth(env.DB, {
-        BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
-        BETTER_AUTH_URL: env.BETTER_AUTH_URL,
-        GOOGLE_CLIENT_ID: env.GOOGLE_CLIENT_ID,
-        GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET,
-        EMAIL_API_KEY: env.EMAIL_API_KEY,
-        EMAIL_FROM: env.EMAIL_FROM,
-      })
+      const auth = createAuthFromEnv(env.DB, env as unknown as Record<string, unknown>)
       const session = await auth.api.getSession({ headers: ctx.request.headers })
       return session?.user?.id ?? null
     } catch (err) {


### PR DESCRIPTION
Fixes #71.

## Problem

`createAuthFromEnv(d1, env)` already exists as the single forwarder that maps **every** auth env var onto `createAuth`. But the main `/api/auth/*` handler and ~11 other call sites still hand-build partial env objects inline. The two drift with no compile-time link — a var added to the forwarder never reaches the inline sites.

Real failure (fork): a signup allowlist (`ALLOWED_AUTH_EMAILS`/`ALLOWED_AUTH_DOMAINS`) read in `databaseHooks.user.create.before`, wired into `createAuthFromEnv`, secrets set and verified — yet every Google sign-in returned `unable_to_create_user`. The OAuth callback runs through the inline handler, which dropped the allowlist vars → empty allowlist → fail-closed → all sign-ins blocked. `createAuthFromEnv` (test-auth path) had them, so the bug hid until the first real OAuth login. The gate's `auth_signup_blocked_no_allowlist` log (both sets empty) was the giveaway.

Even with no allowlist, the inline OAuth handler runs without `APP_NAME`/`APP_URL`/`EMAIL`/`SEND_EMAIL` that the forwarder supplies.

## Change

Every call site now uses:

```ts
const auth = createAuthFromEnv(<env>.DB, <env> as unknown as Record<string, unknown>)
```

Sites: `index.ts` (×2, incl. the OAuth handler), `middleware/{auth,owner,optional-auth}.ts`, `modules/settings/{routes,sessions}.ts`, `modules/spaces/space-agent.ts`. The forwarder is a strict superset of each inline object → behaviour-preserving for the session-validation sites, bug-fixing for the OAuth handler. Net −76 lines.

## Validation

- `pnpm type-check` clean
- Same change applied to a downstream fork (hrhelper): converting all sites was the only edit needed; OAuth sign-in works, allowlist now enforced on the callback path

## Optional follow-up (not in this PR)

Mark the bare `createAuth(d1, {...typed...})` export internal so future code can't reintroduce a hand-built call site — one public constructor makes the contract enforceable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)