### PR TITLE
fix(security): #95 quick group — 6 self-contained high fixes

### DIFF
--- a/src/client/modules/chat/components/chat-ui/PlaceMap.tsx
+++ b/src/client/modules/chat/components/chat-ui/PlaceMap.tsx
@@ -213,7 +213,7 @@ export function PlaceMap({ title, places, center, zoom }: Props) {
                             {p.phone}
                           </a>
                         )}
-                        {p.website && (
+                        {p.website && /^https?:\/\//i.test(p.website) && (
                           <a
                             href={p.website}
                             target="_blank"

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -471,7 +471,10 @@ app.onError((err, c) => {
   // Return error response with request ID for support correlation
   return c.json(
     {
-      error: c.env.NODE_ENV === 'production' ? 'Internal Server Error' : err.message,
+      // Fail safe: only expose the raw message when explicitly in development.
+      // NODE_ENV is usually UNSET on Workers, so `=== 'production'` leaked
+      // internal errors by default. Default (unset/anything else) → generic.
+      error: c.env.NODE_ENV === 'development' ? err.message : 'Internal Server Error',
       requestId,
     },
     500

--- a/src/server/middleware/admin.ts
+++ b/src/server/middleware/admin.ts
@@ -56,21 +56,26 @@ export const adminMiddleware = createMiddleware<AdminContext>(async (c, next) =>
   // Get current user role from database
   const dbUser = await db.query.user.findFirst({
     where: eq(schema.user.id, userId),
-    columns: { role: true },
+    columns: { role: true, emailVerified: true },
   })
 
   const currentRole = dbUser?.role || 'user'
 
-  // Auto-promote if email matches and not already admin
-  if (isAdminEmail && currentRole !== 'admin') {
+  // Auto-promote if email matches AND the email is verified, and not already
+  // admin. The emailVerified gate blocks an unverified email/password account
+  // registered with an ADMIN_EMAILS address from claiming admin (OAuth/Google
+  // sets emailVerified, so the normal admin sign-in path is unaffected).
+  if (isAdminEmail && dbUser?.emailVerified && currentRole !== 'admin') {
     await db
       .update(schema.user)
       .set({ role: 'admin', updatedAt: new Date() })
       .where(eq(schema.user.id, userId))
   }
 
-  // Check authorization - user must be admin by email or DB role
-  const isAdmin = isAdminEmail || currentRole === 'admin'
+  // Check authorization - admin by (verified) email or existing DB role.
+  // isAdminEmail alone is NOT enough: an unverified email/password account
+  // registered with an ADMIN_EMAILS address must not get admin access.
+  const isAdmin = (isAdminEmail && !!dbUser?.emailVerified) || currentRole === 'admin'
 
   if (!isAdmin) {
     return c.json({ error: 'Forbidden - Admin access required' }, 403)

--- a/src/server/modules/batch-tasks/storage.ts
+++ b/src/server/modules/batch-tasks/storage.ts
@@ -131,16 +131,20 @@ export async function startItem(db: D1Database, itemId: string): Promise<void> {
 export async function completeItem(db: D1Database, itemId: string, result: string): Promise<void> {
   const d = drizzle(db)
   const [row] = await d.select().from(batchItems).where(eq(batchItems.id, itemId)).limit(1)
-  if (!row) return
+  if (!row || row.status === 'completed') return // idempotent: already counted
+  const wasFailed = row.status === 'failed'
   await d
     .update(batchItems)
     .set({ status: 'completed', result, completedAt: new Date() })
     .where(eq(batchItems.id, itemId))
-  // Bump parent counts atomically.
+  // Bump parent counts on the state TRANSITION only. A Workflow retry re-runs
+  // this handler; counting unconditionally double-counts. If the item had
+  // previously failed (retry now succeeds), also undo that failed tally.
   await d
     .update(batchJobs)
     .set({
       completedItems: sql`${batchJobs.completedItems} + 1`,
+      ...(wasFailed ? { failedItems: sql`MAX(${batchJobs.failedItems} - 1, 0)` } : {}),
       updatedAt: new Date(),
     })
     .where(eq(batchJobs.id, row.jobId))
@@ -150,6 +154,13 @@ export async function failItem(db: D1Database, itemId: string, error: string): P
   const d = drizzle(db)
   const [row] = await d.select().from(batchItems).where(eq(batchItems.id, itemId)).limit(1)
   if (!row) return
+  if (row.status === 'failed') {
+    // Already counted as failed — a Workflow retry re-entered this handler.
+    // Refresh the error message but do NOT increment failedItems again.
+    await d.update(batchItems).set({ error }).where(eq(batchItems.id, itemId))
+    return
+  }
+  const wasCompleted = row.status === 'completed'
   await d
     .update(batchItems)
     .set({ status: 'failed', error, completedAt: new Date() })
@@ -158,6 +169,7 @@ export async function failItem(db: D1Database, itemId: string, error: string): P
     .update(batchJobs)
     .set({
       failedItems: sql`${batchJobs.failedItems} + 1`,
+      ...(wasCompleted ? { completedItems: sql`MAX(${batchJobs.completedItems} - 1, 0)` } : {}),
       updatedAt: new Date(),
     })
     .where(eq(batchJobs.id, row.jobId))

--- a/src/server/modules/config-diff/apply.ts
+++ b/src/server/modules/config-diff/apply.ts
@@ -6,6 +6,7 @@
  * Everything else (storage, UI, chat tool) is generic.
  */
 import { uploadSkillToR2 } from '@/server/lib/ai/skills/registry'
+import { parseSkill } from '@/server/lib/ai/skills/loader'
 import type { ConfigDiffProposal, ConfigDiffResource } from '@/shared/config/diff-proposal'
 
 export interface ApplyEnv {
@@ -63,6 +64,17 @@ export async function applyProposal(env: ApplyEnv, proposal: ConfigDiffProposal)
       if (!env.SKILLS) {
         throw new Error(
           'SKILLS R2 bucket not configured — cannot persist skill edits. Add the binding in wrangler.jsonc.'
+        )
+      }
+      // Guard against a resource-id mixup: uploadSkillToR2 keys by the
+      // frontmatter `name` of the new content, but this proposal targets
+      // resource.id. If an edit (or AI rewrite) changed the name, applying it
+      // would write to a DIFFERENT skill key — silently overwriting another
+      // skill or orphaning this one. Refuse a name change here.
+      const parsed = parseSkill(proposal.after)
+      if (parsed.frontmatter.name !== proposal.resource.id) {
+        throw new Error(
+          `Skill name mismatch: this change targets "${proposal.resource.id}" but the content declares "${parsed.frontmatter.name}". Renaming a skill through a diff isn't supported — keep the frontmatter name unchanged.`
         )
       }
       // uploadSkillToR2 writes to `${userId}/${name}/SKILL.md` and

--- a/src/server/modules/voice/voice-routes.ts
+++ b/src/server/modules/voice/voice-routes.ts
@@ -22,6 +22,7 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
 import { authMiddleware, type AuthContext } from '@/server/middleware/auth'
+import { consumeRateLimit } from '@/server/middleware/rate-limit'
 import {
   AURA2_SPEAKERS,
   synthesizeSpeech,
@@ -55,6 +56,18 @@ app.get('/voices', (c) => {
  * recorded `Blob` from MediaRecorder under that key.
  */
 app.post('/transcribe', async (c) => {
+  const rl = consumeRateLimit({
+    key: 'VOICE',
+    windowMs: 60 * 60 * 1000,
+    identifier: c.get('userId'),
+    routeKey: 'POST:/api/voice/transcribe',
+  })
+  if (!rl.allowed) {
+    return c.json(
+      { error: 'Voice rate limit exceeded — try again later.', retryAfterSeconds: rl.retryAfterSeconds },
+      429
+    )
+  }
   let form: FormData
   try {
     form = await c.req.formData()
@@ -135,6 +148,18 @@ const ttsBodySchema = z.object({
  * with X-TTS-Provider header so the client knows which provider answered.
  */
 app.post('/tts', zValidator('json', ttsBodySchema), async (c) => {
+  const rl = consumeRateLimit({
+    key: 'VOICE',
+    windowMs: 60 * 60 * 1000,
+    identifier: c.get('userId'),
+    routeKey: 'POST:/api/voice/tts',
+  })
+  if (!rl.allowed) {
+    return c.json(
+      { error: 'Voice rate limit exceeded — try again later.', retryAfterSeconds: rl.retryAfterSeconds },
+      429
+    )
+  }
   const { text, speaker, provider } = c.req.valid('json')
   const env = c.env as unknown as TtsEnv
   try {

--- a/src/shared/config/constants.ts
+++ b/src/shared/config/constants.ts
@@ -86,6 +86,9 @@ export const RATE_LIMITS = {
   /** Structured extraction requests per hour */
   EXTRACT: 30,
 
+  /** Voice transcribe + TTS requests per hour (3rd-party spend protection) */
+  VOICE: 60,
+
   /** AI-Sparkle skill rewrites per hour (one OPENROUTER_API_KEY call each) */
   SKILL_AI_EDIT: 20,
 


### PR DESCRIPTION
Knocks out the self-contained items from #95 (the quick group). Each is its own commit; 136/136 tests pass, type-check clean.

- **admin verify-gate** — `ADMIN_EMAILS` auto-promote AND the authz decision now require `emailVerified`. Blocks an unverified email/password account registered on an admin address from claiming admin (OAuth sets emailVerified, so normal sign-in is unaffected).
- **error-leak fail-safe** — global handler returned `err.message` because `NODE_ENV` is usually unset on Workers (`=== 'production'` was false). Now leaks details only when `NODE_ENV === 'development'`.
- **voice rate limit** — `/api/voice/transcribe` + `/tts` now rate-limited (new `VOICE` limit, 60/hr/user) to cap Deepgram/ElevenLabs spend.
- **PlaceMap scheme** — `show_map` website links render only for `http(s)` URLs (blocks `javascript:`/`data:` XSS from model-supplied place data).
- **batch counter integrity** — `failItem`/`completeItem` now count on the state transition only (idempotent on Workflow retry; undo the opposite tally on flip). Fixes failedItems double-count.
- **config-diff skill rename guard** — applying a skill diff verifies the content's frontmatter name equals `resource.id`, so a renamed skill can't silently overwrite a different one.

### Deferred (still in #95, with reasons)
- `admin/routes.ts:303` protect-admins — policy decision (should admins manage admins? at minimum block self-demotion / last-admin)
- `mailgun.ts:46` — config semantics; changing apiEndpoint-as-domain could break forks relying on it
- `admin-agent.ts:92` model id — needs a live OpenRouter registry check
- `slack/routes.ts:38` token shape — needs the bot-vs-user-token + scope rework
- `scheduler.ts:250` dailyBudget — actually a feature (costUsd is never populated; needs cost tracking + pre-fire aggregate), not a quick fix

Refs #95.