### PR TITLE
fix(security): sign OAuth-connector userId cookies + verify mcp-connections state (auth class #3)

### DIFF
--- a/src/server/lib/crypto.ts
+++ b/src/server/lib/crypto.ts
@@ -83,3 +83,48 @@ export async function generatePkcePair(): Promise<{ verifier: string; challenge:
 export function randomToken(lengthBytes = 32): string {
   return toBase64Url(crypto.getRandomValues(new Uint8Array(lengthBytes)))
 }
+
+/**
+ * Sign a value with HMAC-SHA256 → `${value}.${sig}`. Use for integrity-checking
+ * a value carried through an untrusted round-trip (e.g. a userId or connectionId
+ * in an OAuth-redirect cookie or `state` param). The value is NOT encrypted —
+ * it's readable — only tamper-evident. Secret is BETTER_AUTH_SECRET.
+ */
+export async function signValue(value: string, secret: string | undefined): Promise<string> {
+  if (!secret) throw new Error('BETTER_AUTH_SECRET not set — cannot sign value')
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(value))
+  return `${value}.${toBase64Url(new Uint8Array(mac))}`
+}
+
+/**
+ * Verify a `signValue()` output and return the original value, or null if the
+ * signature is missing/invalid. Constant-time comparison. Reject null before
+ * trusting the value.
+ */
+export async function verifyValue(
+  signed: string | undefined | null,
+  secret: string | undefined
+): Promise<string | null> {
+  if (!signed || !secret) return null
+  const dot = signed.lastIndexOf('.')
+  if (dot <= 0) return null
+  const value = signed.slice(0, dot)
+  let expected: string
+  try {
+    expected = await signValue(value, secret)
+  } catch {
+    return null
+  }
+  if (expected.length !== signed.length) return null
+  let diff = 0
+  for (let i = 0; i < expected.length; i++) diff |= expected.charCodeAt(i) ^ signed.charCodeAt(i)
+  return diff === 0 ? value : null
+}

--- a/src/server/modules/connectors/stub-provider.ts
+++ b/src/server/modules/connectors/stub-provider.ts
@@ -23,7 +23,7 @@ import { eq } from 'drizzle-orm'
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core'
 import { user } from '@/server/modules/auth/db/schema'
 import { authMiddleware, type AuthContext } from '@/server/middleware/auth'
-import { encrypt, decrypt, randomToken } from '@/server/lib/crypto'
+import { encrypt, decrypt, randomToken, signValue, verifyValue } from '@/server/lib/crypto'
 
 /**
  * Creates a per-provider token table definition. Pass a unique physical
@@ -161,7 +161,13 @@ export function buildStubRoutes(config: StubProviderConfig): Hono<AuthContext> {
     if (decodeURIComponent(stateMatch[1]!) !== state) {
       return finish('error', 'State mismatch')
     }
-    const userId = decodeURIComponent(userMatch[1]!)
+    // Verify the HMAC-signed user cookie before trusting it — without this an
+    // authed attacker who knows a victim's userId could write their provider
+    // (slack/notion/atlassian) tokens under the victim's row (token-row hijack).
+    const userId = await verifyValue(decodeURIComponent(userMatch[1]!), env['BETTER_AUTH_SECRET'])
+    if (!userId) {
+      return finish('error', 'Invalid session — try connecting again.')
+    }
 
     if (!isEnabled(env)) {
       return finish('error', `${providerId} is not configured on this server`)
@@ -315,7 +321,7 @@ export function buildStubRoutes(config: StubProviderConfig): Hono<AuthContext> {
     )
     headers.append(
       'Set-Cookie',
-      `${cookiePrefix}_user=${encodeURIComponent(userId)}; ${cookieBase}${secure}`
+      `${cookiePrefix}_user=${encodeURIComponent(await signValue(userId, env['BETTER_AUTH_SECRET']))}; ${cookieBase}${secure}`
     )
     return new Response(JSON.stringify({ authorizationUrl: url.toString() }), { headers })
   })

--- a/src/server/modules/google-workspace/routes.ts
+++ b/src/server/modules/google-workspace/routes.ts
@@ -12,7 +12,7 @@ import { drizzle } from 'drizzle-orm/d1'
 import { eq } from 'drizzle-orm'
 import { authMiddleware, type AuthContext } from '@/server/middleware/auth'
 import { googleWorkspaceTokens } from './db/schema'
-import { encrypt, randomToken } from '@/server/lib/crypto'
+import { encrypt, randomToken, signValue, verifyValue } from '@/server/lib/crypto'
 import {
   exchangeAuthCode,
   isGoogleWorkspaceEnabled,
@@ -53,8 +53,12 @@ app.get('/callback', async (c) => {
   if (!stateMatch || !userMatch) return finish('error', 'Missing session — try connecting again.')
   if (decodeURIComponent(stateMatch[1]!) !== state) return finish('error', 'State mismatch')
 
-  const userId = decodeURIComponent(userMatch[1]!)
   const env = c.env as unknown as GoogleWorkspaceEnv
+  // Verify the HMAC-signed gws_user cookie — without this an authed attacker
+  // who knows a victim's userId could substitute it and write their Google
+  // tokens under the victim's row (token-row hijack).
+  const userId = await verifyValue(decodeURIComponent(userMatch[1]!), env.BETTER_AUTH_SECRET)
+  if (!userId) return finish('error', 'Invalid session — try connecting again.')
 
   if (!isGoogleWorkspaceEnabled(env)) {
     return finish('error', 'Google Workspace is not configured on this server')
@@ -181,7 +185,10 @@ app.post('/connect', async (c) => {
   const secure = env.BETTER_AUTH_URL?.startsWith('https://') ? '; Secure' : ''
   const headers = new Headers({ 'Content-Type': 'application/json' })
   headers.append('Set-Cookie', `gws_state=${encodeURIComponent(state)}; ${cookieBase}${secure}`)
-  headers.append('Set-Cookie', `gws_user=${encodeURIComponent(userId)}; ${cookieBase}${secure}`)
+  headers.append(
+    'Set-Cookie',
+    `gws_user=${encodeURIComponent(await signValue(userId, env.BETTER_AUTH_SECRET))}; ${cookieBase}${secure}`
+  )
 
   return new Response(JSON.stringify({ authorizationUrl: authUrl.toString() }), { headers })
 })

--- a/src/server/modules/google-workspace/tokens.ts
+++ b/src/server/modules/google-workspace/tokens.ts
@@ -35,6 +35,7 @@ export interface GoogleWorkspaceEnv {
   GOOGLE_WORKSPACE_CLIENT_ID?: string
   GOOGLE_WORKSPACE_CLIENT_SECRET?: string
   BETTER_AUTH_URL?: string
+  BETTER_AUTH_SECRET?: string
   TOKEN_ENCRYPTION_KEY?: string
 }
 

--- a/src/server/modules/mcp-connections/routes.ts
+++ b/src/server/modules/mcp-connections/routes.ts
@@ -13,7 +13,7 @@ import { and, eq } from 'drizzle-orm'
 import { authMiddleware, type AuthContext } from '@/server/middleware/auth'
 import { userMcpConnections, userMcpToolPolicies } from './db/schema'
 import { probeMcpServer, registerOAuthClient } from './probe'
-import { encrypt, decrypt, generatePkcePair, randomToken } from '@/server/lib/crypto'
+import { encrypt, decrypt, generatePkcePair, signValue, verifyValue } from '@/server/lib/crypto'
 import { MCP_CATALOG, findCatalogEntry } from '@/shared/config/connector-catalog'
 
 const app = new Hono<AuthContext>()
@@ -50,6 +50,12 @@ app.get('/callback', async (c) => {
   }
   const pkceVerifier = decodeURIComponent(pkceMatch[1]!)
   const connectionId = decodeURIComponent(connectionMatch[1]!)
+  // Verify the OAuth state binds to this connection (HMAC-signed connectionId).
+  // Previously state was accepted without any check.
+  const stateConnId = await verifyValue(state, c.env.BETTER_AUTH_SECRET)
+  if (!stateConnId || stateConnId !== connectionId) {
+    return c.html(callbackPage({ status: 'error', message: 'Invalid OAuth state — try connecting again.' }))
+  }
 
   const db = drizzle(c.env.DB)
   const [conn] = await db
@@ -277,7 +283,9 @@ app.post('/connect', zValidator('json', connectSchema), async (c) => {
   }
 
   const { verifier, challenge } = await generatePkcePair()
-  const state = randomToken()
+  // State is the HMAC-signed connectionId so the callback can verify it binds
+  // to a connect THIS server issued (the callback previously trusted any state).
+  const state = await signValue(connectionId, c.env.BETTER_AUTH_SECRET)
 
   const row = {
     id: connectionId,
@@ -378,7 +386,7 @@ app.post('/:id/authorize', async (c) => {
 
   const redirectUri = new URL('/api/mcp-connections/callback', c.env.BETTER_AUTH_URL).toString()
   const { verifier, challenge } = await generatePkcePair()
-  const state = randomToken()
+  const state = await signValue(id, c.env.BETTER_AUTH_SECRET)
 
   const authUrl = new URL(conn.authorizationEndpoint)
   authUrl.searchParams.set('response_type', 'code')

--- a/src/server/modules/microsoft-workspace/routes.ts
+++ b/src/server/modules/microsoft-workspace/routes.ts
@@ -16,7 +16,7 @@ import { drizzle } from 'drizzle-orm/d1'
 import { eq } from 'drizzle-orm'
 import { authMiddleware, type AuthContext } from '@/server/middleware/auth'
 import { microsoftWorkspaceTokens } from './db/schema'
-import { encrypt, randomToken } from '@/server/lib/crypto'
+import { encrypt, randomToken, signValue, verifyValue } from '@/server/lib/crypto'
 import {
   exchangeAuthCode,
   isMicrosoftWorkspaceEnabled,
@@ -58,8 +58,10 @@ app.get('/callback', async (c) => {
   if (!stateMatch || !userMatch) return finish('error', 'Missing session — try connecting again.')
   if (decodeURIComponent(stateMatch[1]!) !== state) return finish('error', 'State mismatch')
 
-  const userId = decodeURIComponent(userMatch[1]!)
   const env = c.env as unknown as MicrosoftWorkspaceEnv
+  // Verify the HMAC-signed msw_user cookie before trusting it (token-row hijack).
+  const userId = await verifyValue(decodeURIComponent(userMatch[1]!), env.BETTER_AUTH_SECRET)
+  if (!userId) return finish('error', 'Invalid session — try connecting again.')
 
   if (!isMicrosoftWorkspaceEnabled(env)) {
     return finish('error', 'Microsoft Workspace is not configured on this server')
@@ -184,7 +186,10 @@ app.post('/connect', async (c) => {
   const secure = env.BETTER_AUTH_URL?.startsWith('https://') ? '; Secure' : ''
   const headers = new Headers({ 'Content-Type': 'application/json' })
   headers.append('Set-Cookie', `msw_state=${encodeURIComponent(state)}; ${cookieBase}${secure}`)
-  headers.append('Set-Cookie', `msw_user=${encodeURIComponent(userId)}; ${cookieBase}${secure}`)
+  headers.append(
+    'Set-Cookie',
+    `msw_user=${encodeURIComponent(await signValue(userId, env.BETTER_AUTH_SECRET))}; ${cookieBase}${secure}`
+  )
 
   return new Response(JSON.stringify({ authorizationUrl: authUrl.toString() }), { headers })
 })

--- a/src/server/modules/microsoft-workspace/tokens.ts
+++ b/src/server/modules/microsoft-workspace/tokens.ts
@@ -71,6 +71,7 @@ export interface MicrosoftWorkspaceEnv {
    */
   MICROSOFT_WORKSPACE_TENANT?: string
   BETTER_AUTH_URL?: string
+  BETTER_AUTH_SECRET?: string
   TOKEN_ENCRYPTION_KEY?: string
 }
 


### PR DESCRIPTION
Closes the third auth/access-control class from the 2026-06-23 fork sweep (HR Helper). Classes #1 (signup allowlist gate) and #2 (session.create.before login re-check + TEST_AUTH_TOKEN-gated exemption) were already in `main` from PR #94 — verified present before this change.

## #3 — unsigned `*_user` cookie → token-row hijack (HIGH)

The OAuth-connector flows carried the connecting `userId` through the provider redirect in a **plaintext, unsigned** cookie (`gws_user` / `msw_user` / `<prefix>_user`), trusted verbatim in the public `/callback`. Any authenticated attacker who knew a victim's `userId` could substitute it and have *their* provider tokens written under the **victim's** row.

- New `signValue()` / `verifyValue()` in `src/server/lib/crypto.ts` (HMAC-SHA256 over `BETTER_AUTH_SECRET`, constant-time verify).
- `google-workspace`, `microsoft-workspace`, `connectors/stub-provider` (slack/notion/atlassian): sign the userId cookie at `/connect`, verify at `/callback`, reject on failure.
- `mcp-connections`: the callback validated **no** `state` at all. Now `state = signValue(connectionId)` at connect/reconnect, verified to equal the cookie's connectionId in the callback.

**Verification:** a real connect→callback still completes (same secret signs + verifies); a forged/substituted `*_user` cookie or mismatched `state` is rejected. Type-check clean, 136/136 tests pass.

Companion to the per-fork tracking issues being filed for forks that predate these starter fixes.