### PR TITLE
docs: hardened access-control model — new SECURITY.md + Auth/checklist updates

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -37,10 +37,12 @@ GOOGLE_CLIENT_SECRET=your-client-secret
 # ENABLE_EMAIL_SIGNUP=true  → Also allow new email signups (requires ENABLE_EMAIL_LOGIN)
 #
 # The UI automatically adapts based on these settings via /api/auth/config
-# Google OAuth is NOT affected (use Google Cloud domain restriction instead)
-# To restrict Google OAuth: Set OAuth consent screen "User type" to "Internal"
 #
-# See CLAUDE.md "Auth Method Control" section for full documentation.
+# Restricting WHO can sign in (incl. Google OAuth) is done IN CODE via the
+# allowlist below — NOT only the Google consent screen. A consent screen set to
+# "External" (required whenever any user is on a non-Workspace domain) lets ANY
+# Google account sign in; the consent screen is defence-in-depth, not the gate.
+# See CLAUDE.md "Auth" section and docs/SECURITY.md.
 
 # Uncomment to enable email/password authentication:
 # ENABLE_EMAIL_LOGIN=true
@@ -49,10 +51,13 @@ GOOGLE_CLIENT_SECRET=your-client-secret
 # ============================================
 # Signup Allowlist - OPTIONAL (issue #88)
 # ============================================
-# Invite-only / single-tenant gate. The gate ACTIVATES when either list below
-# is set (or AUTH_ALLOWLIST=true); only matching emails can then create an
-# account. Fires on account CREATION only — existing users are never locked out.
-# Unset (default) → open signup, so a fresh public fork is unaffected.
+# Invite-only / single-tenant gate, enforced in code (src/server/modules/auth/
+# index.ts, isSignupAllowed). The gate ACTIVATES when either list below is set
+# (or AUTH_ALLOWLIST=true); only matching emails can then sign in. Enforced on
+# BOTH account creation (user.create.before) AND every login (session.create.
+# before) — so removing an operator (or a row predating the gate) locks them out
+# on next sign-in too. Unset (default) → open signup, so a fresh public fork is
+# unaffected.
 # Blocked sign-ins surface as "This account isn't authorised" on the sign-in
 # page (see issue #69). Pairs with VITE_TENANCY_MODE=shared for a turnkey
 # single-tenant deployment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ VITE_FEATURE_ACTIVITY=false
 | **knowledge** | Long-form indexed reference docs per scope (user/project/org). FTS5-indexed, two injection modes (`always` bakes body into every prompt, `on_demand` exposes catalog the agent searches via `knowledge_search` + `load_knowledge`). Server-side cap at 50K total always-active tokens. Sits between `memories` (small structured facts) and `skills` (procedures). | `server/modules/knowledge/`, `client/modules/knowledge/`, `server/modules/chat/chat-agent.ts` (section 8c) |
 | **voice mode** | Push-to-talk + auto-TTS wrapper around the chat agent. Aura 2 default + ElevenLabs opt-in. iOS Safari unlock via primed audio element, AbortController + 25s timeout, race-safe via session counter. Distinct from VoiceDictationButton (which streams STT into the input field via DO+WS). | `server/modules/voice/`, `client/modules/chat/components/VoiceModeButton.tsx`, `client/modules/chat/hooks/useVoiceChat.ts` |
 | **tool-renderer shape tier** | Generic tool-output viewers matched by output shape rather than tool name — auto-upgrades ~30 long-tail tools to rich UX with zero per-tool client code. Shapes: stdout/image/markdown/table. Registered after bespoke renderers, before defaults. `pnpm tool-coverage` audits the registry. | `client/modules/chat/components/tool-renderers/shapes.tsx`, `scripts/tool-coverage.mjs` |
+| **access log** | Cross-user activity log for app owners — `GET /api/admin/access-log` (auth+admin gated) over the existing `activity_logs` table, filterable by user/action/entity/date, actor-email enriched. Per-user `/api/activity` shows only your own rows; this answers "what has any user done in this app?". | `server/modules/admin/routes.ts` (access-log route), `client/modules/admin/pages/AccessLogPage.tsx` |
+| **security primitives** | Single-source-of-truth guards reused across modules: `scopeUser`/`getOrgRole` (tenancy), `isOwnedR2Key` (R2 ownership), `signValue`/`verifyValue` (signed OAuth-redirect cookies + mcp state), `isSafePublicUrl`/`isAllowedGitHubUrl` (SSRF), `escapeHtml` (reflected-XSS), `bytesToBase64` (large-file safe), fail-closed `AGENT_ACCESS_POLICY` (DO access). Full model: `docs/SECURITY.md`. | `server/lib/{tenancy,r2-keys,crypto,ssrf,escape-html,base64}.ts`, `server/index.ts` |
 | **brains-trust pattern** | After non-trivial builds, run a multi-reviewer review via 2-4 frontier models (GPT-5.5 + Opus 4.7 + DeepSeek v4 Pro/Flash) — cross-validated criticals fixed before commit; cross-validated highs before deploy. ~$0.46-$0.81/round. Codified in `~/.claude/CLAUDE.md`. Audit artefacts saved to `.jez/audits/<date>-brains-trust-<topic>.md`. | (process; see `.jez/audits/2026-05-07-tool-ui-and-connectors-brains-trust.md` for a worked example) |
 
 ---
@@ -110,6 +112,7 @@ reference lives in `docs/`, loaded only when you need it.
 | Want to… | Read |
 |---|---|
 | **Onboard fresh** (humans OR AI sessions) — fastest orientation | [`docs/ONBOARDING.md`](./docs/ONBOARDING.md) |
+| **Secure a deployment** — access-control model + pre-deploy checklist | [`docs/SECURITY.md`](./docs/SECURITY.md) |
 | **Build a specific product** (email triage, CRM, Jira, support, docs) | [`docs/AGENT_PLAYBOOKS.md`](./docs/AGENT_PLAYBOOKS.md) |
 | **Architectural rationale** — why the starter looks like this, what we adopted from other frameworks | [`docs/PLATFORM_OBSERVATIONS.md`](./docs/PLATFORM_OBSERVATIONS.md) |
 | Build a CRUD feature, table, hook | [`docs/PATTERNS.md`](./docs/PATTERNS.md) |
@@ -605,9 +608,21 @@ fresh-fork auth issues are environmental, not code.
 
 - **OAuth-only by default** — set `ENABLE_EMAIL_LOGIN=true` for
   email/password.
-- Google OAuth with optional domain restriction via Google Cloud Console.
+- **Who can sign in is gated IN CODE, not just the Google consent screen.**
+  Set `ALLOWED_AUTH_EMAILS` / `ALLOWED_AUTH_DOMAINS` (or `AUTH_ALLOWLIST=true`
+  to fail closed) — enforced by `isSignupAllowed` in BOTH
+  `databaseHooks.user.create.before` (new signups) AND `session.create.before`
+  (every login, so a removed operator is locked out on next sign-in). Unset →
+  open signup (public-starter default). The consent screen is defence-in-depth;
+  an "External" app otherwise lets any Google account in. See `docs/SECURITY.md`.
 - Session management: 7-day expiry, revoke on password change.
-- Admin role via `ADMIN_EMAILS` env var.
+- Admin role via `ADMIN_EMAILS` env var — auto-promote requires a **verified**
+  email (an unverified email/password account on an admin address can't claim admin).
+- **OAuth connectors sign their state cookies.** The connecting `userId` carried
+  through a provider redirect (`gws_user`/`msw_user`/`<prefix>_user`) is
+  HMAC-signed (`signValue`/`verifyValue`, `src/server/lib/crypto.ts`) and verified
+  in the callback, so an attacker can't substitute a victim's id to hijack their
+  token row. `mcp-connections` binds OAuth `state = signValue(connectionId)`.
 - **last-login-method** — better-auth plugin drops a
   `better-auth.last_used_login_method` cookie after each successful
   sign-in. The login page reads it client-side and surfaces a "Last
@@ -708,4 +723,4 @@ pnpm type-check             # Type check
 
 ---
 
-**Created:** 2025-11-29 · **Updated:** 2026-05-04 · **Author:** Jeremy Dawes (Jezweb)
+**Created:** 2025-11-29 · **Updated:** 2026-06-23 (security review: allowlist, signed connector cookies, access log, tenancy/R2 guards — see `docs/SECURITY.md`) · **Author:** Jeremy Dawes (Jezweb)

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -45,9 +45,25 @@ echo "production" | npx wrangler secret put SENTRY_ENVIRONMENT
 echo "your-gateway-id" | npx wrangler secret put AI_GATEWAY_ID
 echo "your-token" | npx wrangler secret put CF_AIG_TOKEN
 
-# Optional: Admin auto-promotion
+# Optional: Admin auto-promotion (admin promote requires a VERIFIED email)
 echo "admin@yourcompany.com,cto@yourcompany.com" | npx wrangler secret put ADMIN_EMAILS
+
+# Sign-in allowlist — gate WHO can sign in (incl. Google OAuth), enforced in code.
+# Private/team apps: set a domain (and/or explicit emails). Public apps: leave unset.
+# The Google consent screen is NOT sufficient — an "External" app lets any Google
+# account in. See docs/SECURITY.md.
+echo "yourcompany.com" | npx wrangler secret put ALLOWED_AUTH_DOMAINS
+# echo "alice@x.com,bob@x.com" | npx wrangler secret put ALLOWED_AUTH_EMAILS
+# echo "true" | npx wrangler secret put AUTH_ALLOWLIST   # fail closed with empty lists
+
+# Required if using OAuth connectors (Gmail/Slack/Notion/Atlassian/MCP) — used for
+# connector token encryption AND signed OAuth-redirect cookies.
+echo "$(openssl rand -hex 32)" | npx wrangler secret put TOKEN_ENCRYPTION_KEY
 ```
+
+> **Before going live, walk `docs/SECURITY.md` § "Pre-deploy checklist".** It
+> covers the allowlist decision, R2/tenancy scoping, the agent access gate, and
+> the connector token/cookie protections.
 
 ### 3. Database Migration
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,112 @@
+# Security & Access Control
+
+The access-control model every fork inherits. Read this before deploying to real
+users. It consolidates the guarantees the starter enforces and the levers you set
+per deployment. (Hardened in the 2026-06 security review — see `.jez/review/register.md`.)
+
+---
+
+## 1. Who can sign in — the allowlist gate
+
+**Restricting sign-in is done in code, not just the Google consent screen.** A
+consent screen set to "External" (required whenever any user is on a non-Workspace
+domain) lets *any* Google account in. The code allowlist is the real gate; the
+consent screen is defence-in-depth.
+
+`isSignupAllowed(email, env)` (`src/server/modules/auth/index.ts`) gates on:
+
+| Env var | Effect |
+|---|---|
+| `ALLOWED_AUTH_EMAILS` | comma list of exact addresses allowed |
+| `ALLOWED_AUTH_DOMAINS` | comma list of domains allowed (no `@`) |
+| `AUTH_ALLOWLIST=true` | force the gate on with empty lists → **fail closed** (reject all) |
+
+- **Unset** (default) → open signup, so a fresh public fork is unaffected.
+- Enforced in **two** hooks so it can't be half-applied:
+  - `databaseHooks.user.create.before` — blocks new non-allowlisted signups.
+  - `databaseHooks.session.create.before` — re-checks on **every login**, so an
+    account that predates the allowlist (or an operator you removed) is locked
+    out on next sign-in, not just at signup.
+- Test users (`*@test.<x>.local`) are exempt **only** when `TEST_AUTH_TOKEN` is
+  set — exempt-by-construction, never a bare TLD/regex bypass.
+
+**Per-deployment lever:** a private/team app should set `ALLOWED_AUTH_DOMAINS`
+(e.g. `jezweb.net`). A public app leaves it unset (open) but should expect — and
+rate-limit / budget — anonymous AI usage.
+
+**Verify live:** `wrangler d1 execute <db> --remote --command "SELECT email, createdAt FROM user ORDER BY createdAt"` — any address outside your operator set is unauthorised access.
+
+## 2. Admin role
+
+`ADMIN_EMAILS` auto-promotes matching users to `admin` — but **only if their email
+is verified** (`emailVerified`), so an unverified email/password account registered
+on an admin address can't claim admin. OAuth (Google) sets `emailVerified`, so the
+normal admin sign-in path is unaffected.
+
+## 3. Tenancy isolation
+
+Rows are scoped to their creator (`userId`). Use `scopeUser(table.userId, userId)`
+(`src/server/lib/tenancy.ts`) for **reads and write-guards** — it returns the
+condition in per-user mode and `undefined` in shared mode (`VITE_TENANCY_MODE=shared`),
+so the two never drift. Org-scoped data is gated by membership via `getOrgRole()`.
+Never take a tenancy scope (`orgId`/`projectId`/`userId`) from a client query param;
+derive it from the session.
+
+## 4. R2 object ownership
+
+R2 objects are stored under user-scoped key prefixes (`users/<userId>/…`). Any route
+that serves an object from a caller-supplied key MUST gate on
+`isOwnedR2Key(key, userId)` (`src/server/lib/r2-keys.ts`) — one source of truth used
+by the files, images, and media modules and the image agent tools. Without it, a
+logged-in user reads another tenant's files by guessing the key (IDOR).
+
+## 5. Durable Object / agent access
+
+`/agents/*` is gated by a **fail-closed per-class policy** (`AGENT_ACCESS_POLICY` in
+`src/server/index.ts`): an agent class with no declared policy is **denied**. Policies:
+`owner-chat` (ChatAgent `user-<id>-conv-<id>`), `owner-colon` (AutonomousAgents +
+voice/video, owner = segment before the first `:`), `do-enforced` (SpaceAgent — the
+DO checks membership itself). Adding a new agent is secure by default. Routines run
+with `setOwner(routine.userId)` and an owner-namespaced agent name; routine
+`agentClass` is allowlisted against the registry.
+
+## 6. OAuth connector token security
+
+The connecting `userId` carried through a provider redirect is HMAC-signed
+(`signValue`/`verifyValue`, `src/server/lib/crypto.ts`) in the `*_user` cookie and
+verified in the callback, so it can't be substituted to hijack a victim's token row.
+`mcp-connections` binds `state = signValue(connectionId)` and verifies it.
+Connector access tokens are stored AES-GCM encrypted and **decrypted before use**
+(never sent as ciphertext).
+
+## 7. Injection / SSRF / XSS
+
+- **SSRF:** server-side fetch of a user-supplied URL goes through
+  `isSafePublicUrl` (blocks localhost/internal/private-IP/metadata) or a host
+  allowlist (`isAllowedGitHubUrl`) — `src/server/lib/ssrf.ts`.
+- **Reflected XSS:** any user/provider value interpolated into HTML (OAuth callback
+  pages) runs through `escapeHtml` (`src/server/lib/escape-html.ts`).
+- **Webhooks:** signatures compared in constant time; Stripe verified with the
+  `t=…,v1=…` scheme over `<timestamp>.<body>`.
+
+## 8. Audit / access log
+
+Every module records user actions via `logActivity()` into `activity_logs`
+(action, entity, IP, user-agent, field-level changes, timestamp). App owners review
+cross-user activity at **`GET /api/admin/access-log`** (auth + admin gated) and the
+**`/dashboard/admin/access-log`** UI (filter by user / action / entity / date).
+Forks extend coverage by calling `logActivity()` for their own domain actions.
+
+---
+
+## Pre-deploy checklist (security)
+
+- [ ] Decide sign-in policy: set `ALLOWED_AUTH_*` for private/team apps; leave open
+      only for genuine public apps (and rate-limit AI usage).
+- [ ] `BETTER_AUTH_SECRET` and `TOKEN_ENCRYPTION_KEY` set as wrangler secrets
+      (used for cookie signing + connector token encryption).
+- [ ] `ADMIN_EMAILS` set to real operators.
+- [ ] If using OAuth connectors, confirm the callback host (`BETTER_AUTH_URL`) is correct.
+- [ ] New domain modules use `scopeUser()` on reads + write-guards.
+- [ ] New routes serving R2 by key gate on `isOwnedR2Key()`.
+- [ ] New agent classes declare an `AGENT_ACCESS_POLICY` entry.


### PR DESCRIPTION
Documents the 2026-06 security work so forks (and future sessions) have the model written down before propagating fixes.

- **New `docs/SECURITY.md`** — the consolidated access-control model + a pre-deploy security checklist: allowlist gate (signup **and** login), admin verify-gate, tenancy (`scopeUser`/`getOrgRole`), R2 ownership (`isOwnedR2Key`), fail-closed `AGENT_ACCESS_POLICY`, signed OAuth-connector cookies + mcp `state`, SSRF/XSS/webhook guards, and the cross-user access log.
- **CLAUDE.md** — Auth section rewritten to kill the "restrict via Google consent screen" myth (sign-in is gated **in code**); admin auto-promote requires a verified email; signed connector cookies noted. Added SECURITY.md to "Where to find things" and the access-log module + shared security primitives to the module map.
- **.dev.vars.example** — corrected the consent-screen note; clarified the allowlist enforces on login too.
- **DEPLOYMENT_CHECKLIST.md** — `ALLOWED_AUTH_*` + `TOKEN_ENCRYPTION_KEY` secrets + a pointer to the SECURITY.md checklist.

Pairs with #94 (merged), #96, #97.