### PR TITLE
fix(security): video-agent model allowlist + per-owner rate limit + CSP wss/blob

### DIFF
--- a/src/server/middleware/security.ts
+++ b/src/server/middleware/security.ts
@@ -35,9 +35,9 @@ export const securityHeaders = createMiddleware<{ Bindings: Env }>(async (c, nex
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline'", // unsafe-inline for Vite HMR in dev
       "style-src 'self' 'unsafe-inline'", // inline styles from components
-      "img-src 'self' data: https:", // Allow https images
+      "img-src 'self' data: https: blob:", // https images + canvas/blob URLs (video frame capture)
       "font-src 'self' data:",
-      "connect-src 'self' https://accounts.google.com", // Google OAuth
+      "connect-src 'self' https://accounts.google.com wss:", // Google OAuth + agent WebSockets
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/src/server/modules/video/video-agent.ts
+++ b/src/server/modules/video/video-agent.ts
@@ -81,10 +81,15 @@ export class VideoInputExample extends Agent<any> {
 
     if (data.type !== 'frame') return
 
+    // Rate-limit per OWNER, not per DO instance name. The instance name is
+    // `<userId>:<sessionId>` (client picks sessionId), so keying on this.name
+    // let a user cycle sessionIds for unlimited fresh buckets. Key on the
+    // userId prefix instead.
+    const ownerId = this.name.split(':')[0] || this.name
     const rateLimit = consumeRateLimit({
       key: 'CHAT',
       windowMs: 60 * 60 * 1000,
-      identifier: this.name,
+      identifier: ownerId,
       routeKey: 'WS:VideoInputExample:frame',
     })
     if (!rateLimit.allowed) {
@@ -103,18 +108,22 @@ export class VideoInputExample extends Agent<any> {
       return
     }
 
+    // Model allowlist: this is a free-tier vision demo. A client-supplied
+    // model was passed straight to resolveModel, which routes paid prefixes
+    // (anthropic/, openrouter/, gpt-*) to the operator's keys — a credit-drain
+    // vector over the WebSocket. Only allow Workers AI (@cf/ / @hf/) models;
+    // anything else falls back to the default.
+    const requested = typeof data.model === 'string' ? data.model : ''
+    const safeModel =
+      requested.startsWith('@cf/') || requested.startsWith('@hf/') ? requested : this.defaultModel
     const start = Date.now()
     try {
-      const caption = await this.captionFrame(
-        data.image,
-        data.prompt,
-        data.model ?? this.defaultModel
-      )
+      const caption = await this.captionFrame(data.image, data.prompt, safeModel)
       this.broadcast(
         JSON.stringify({
           type: 'caption',
           text: caption,
-          model: data.model ?? this.defaultModel,
+          model: safeModel,
           durationMs: Date.now() - start,
           ts: Date.now(),
         })


### PR DESCRIPTION
Found by the post-sweep **focused security review** (the video example agent was outside the original fix scope).

- **video-agent** `data.model` over WebSocket → `resolveModel` with no allowlist routed paid prefixes (anthropic/openrouter/gpt) to the operator's keys (credit-drain). Now allowlisted to `@cf/`/`@hf/` vision models. (HIGH)
- **video-agent** frame rate-limit keyed on `this.name` (`<userId>:<sessionId>`, client-chosen) → cyclable. Now keys on the userId prefix.
- **CSP middleware** missing `wss:`/`blob:` that `public/_headers` had — aligned (agent WebSockets + video frame capture).

The review otherwise **confirmed the 2026-06 sweep fixes hold on main** — the bulk of its crit/high were stale-read false positives (flagging the old vuln shape on already-patched code), verified false by inspection. Type-check clean.