### PR TITLE
fix(security): 4 remaining HIGH findings — admin authz, model id, Slack token, routine budget (#95)

### DIFF
--- a/src/server/modules/admin/routes.ts
+++ b/src/server/modules/admin/routes.ts
@@ -358,8 +358,11 @@ adminRoutes.patch('/users/:id', zValidator('json', updateUserSchema), async (c) 
     return c.json({ error: 'User not found' }, 404)
   }
 
-  // Prevent modifying other admins
-  if (isAdminEmail(existingUser.email, c.env.ADMIN_EMAILS)) {
+  // Prevent modifying other admins — by env allowlist OR by DB role. The
+  // DB-role check matters once anyone is promoted through the panel: without
+  // it, one admin could demote/rename/re-email another admin who isn't in
+  // ADMIN_EMAILS (admin-vs-admin escalation / lockout).
+  if (isAdminEmail(existingUser.email, c.env.ADMIN_EMAILS) || existingUser.role === 'admin') {
     return c.json({ error: 'Cannot modify another admin user' }, 403)
   }
 
@@ -423,8 +426,9 @@ adminRoutes.delete('/users/:id', async (c) => {
     return c.json({ error: 'User not found' }, 404)
   }
 
-  // Prevent deleting other admins
-  if (isAdminEmail(user.email, c.env.ADMIN_EMAILS)) {
+  // Prevent deleting other admins — by env allowlist OR by DB role (same
+  // admin-vs-admin protection as the PATCH guard above).
+  if (isAdminEmail(user.email, c.env.ADMIN_EMAILS) || user.role === 'admin') {
     return c.json({ error: 'Cannot delete another admin user' }, 403)
   }
 

--- a/src/server/modules/autonomous-agents/admin-agent.ts
+++ b/src/server/modules/autonomous-agents/admin-agent.ts
@@ -89,7 +89,13 @@ export class AdminAgent extends AutonomousAgent<Env, AutonomousAgentState> {
     // chain (list → reason → propose), so the better tool-loop model is
     // worth the marginal cost. Forks can override via setState if they
     // want Haiku for cost.
-    modelId: 'anthropic/claude-sonnet-4-6',
+    //
+    // Catalogue/OpenRouter id format uses a DOT (`claude-sonnet-4.6`).
+    // The dash form (`4-6`) is only the direct-Anthropic SDK spelling, which
+    // resolveModel derives via regex on the direct path. On the default
+    // OpenRouter-only deployment the dash form is forwarded verbatim and 404s
+    // ("model not found"), so keep the dotted catalogue id here.
+    modelId: 'anthropic/claude-sonnet-4.6',
   }
 
   protected override async getToolDefinitions(): Promise<ToolDefinition<unknown, unknown>[]> {

--- a/src/server/modules/connectors/stub-provider.ts
+++ b/src/server/modules/connectors/stub-provider.ts
@@ -103,6 +103,27 @@ export interface StubProviderConfig {
   includeRedirectUriInTokenExchange?: boolean
   /** Extra params to include on the authorize URL (e.g. Notion's `owner=user`). */
   extraAuthParams?: Record<string, string>
+  /**
+   * Query-param name carrying the requested scopes on the authorize URL.
+   * Default `'scope'`. Slack's OAuth v2 puts USER-token scopes on
+   * `user_scope` (`scope` is for bot-token scopes), so it overrides this so
+   * the install returns a user token we can act as.
+   */
+  scopeParam?: string
+  /**
+   * Map a provider's token-exchange response into the standard
+   * `{ access_token, refresh_token?, expires_in?, scope? }` shape. Default:
+   * read those fields off the top level. Slack returns the user bearer at
+   * `authed_user.access_token` (top-level `access_token` is the BOT token),
+   * so it overrides this to avoid storing the wrong token. Throw to surface a
+   * provider-reported error (e.g. Slack `{ ok: false }`).
+   */
+  extractToken?: (raw: unknown) => {
+    access_token: string
+    refresh_token?: string
+    expires_in?: number
+    scope?: string
+  }
 }
 
 /** Generic env shape for stub providers. DB is read as the standard D1
@@ -195,7 +216,11 @@ export function buildStubRoutes(config: StubProviderConfig): Hono<AuthContext> {
         const errText = await resp.text()
         throw new Error(`Token exchange failed: ${resp.status} ${errText.slice(0, 200)}`)
       }
-      const json = (await resp.json()) as {
+      const raw = await resp.json()
+      // extractToken lets a provider with a non-standard response shape
+      // (Slack: user bearer at authed_user.access_token) map into the
+      // standard token bag before we store it. Default reads top-level fields.
+      const json = (config.extractToken ? config.extractToken(raw) : raw) as {
         access_token: string
         refresh_token?: string
         expires_in?: number
@@ -304,7 +329,8 @@ export function buildStubRoutes(config: StubProviderConfig): Hono<AuthContext> {
     url.searchParams.set('client_id', env[envVars.clientId]!)
     url.searchParams.set('redirect_uri', redirectUri(env))
     url.searchParams.set('response_type', 'code')
-    url.searchParams.set('scope', config.scopes.join(' '))
+    // Slack carries user-token scopes on `user_scope`, not `scope`.
+    url.searchParams.set(config.scopeParam ?? 'scope', config.scopes.join(' '))
     url.searchParams.set('state', state)
     if (config.extraAuthParams) {
       for (const [k, v] of Object.entries(config.extraAuthParams)) {

--- a/src/server/modules/routines/scheduler.ts
+++ b/src/server/modules/routines/scheduler.ts
@@ -23,8 +23,9 @@
  * timers (e.g. inside a single run, schedule a follow-up step).
  */
 import { drizzle } from 'drizzle-orm/d1'
-import { and, asc, eq, isNull, lt, lte, or, sql } from 'drizzle-orm'
+import { and, asc, eq, gte, isNull, lt, lte, or, sql } from 'drizzle-orm'
 import { routines, routineRuns, type RoutineOutcome } from './db/schema'
+import { agentRuns } from '@/server/modules/agent-observability/db/schema'
 import {
   startRoutineRun,
   finishRoutineRun,
@@ -110,6 +111,27 @@ export async function processDueRoutines(
             timezone: tz,
             currentHour,
             wantedHour: r.localFireHour,
+          })
+        )
+        continue
+      }
+    }
+
+    // Daily budget gate. dailyBudgetUsd caps how much this routine's agent
+    // may spend per UTC day; the authoritative cost lives in agent_runs.
+    // When today's spend has reached the cap we skip the fire (leaving
+    // lastRunAt untouched so it's reconsidered next tick — and naturally
+    // unblocks after UTC midnight). One cheap SUM per over-budget routine.
+    if (r.dailyBudgetUsd != null && r.dailyBudgetUsd > 0) {
+      const spent = await spentTodayUsd(db, r.agentClass, r.agentName)
+      if (spent >= r.dailyBudgetUsd) {
+        console.log(
+          JSON.stringify({
+            event: 'routine_skipped_budget',
+            routineId: r.id,
+            userId: r.userId,
+            spentUsd: spent,
+            dailyBudgetUsd: r.dailyBudgetUsd,
           })
         )
         continue
@@ -271,6 +293,32 @@ export async function fireRoutine(
       })
     )
   }
+}
+
+/**
+ * Sum a routine agent's USD spend since UTC midnight today, from the
+ * authoritative agent_runs telemetry. A routine targets a specific
+ * (agentClass, agentName) instance, so summing those rows is the routine's
+ * daily spend. Returns 0 when nothing has run yet.
+ */
+async function spentTodayUsd(
+  db: ReturnType<typeof drizzle>,
+  agentClass: string,
+  agentName: string
+): Promise<number> {
+  const now = Math.floor(Date.now() / 1000)
+  const startOfDay = now - (now % 86400) // epoch days align to UTC midnight
+  const [row] = await db
+    .select({ total: sql<number>`COALESCE(SUM(${agentRuns.costUsd}), 0)` })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.agentClass, agentClass),
+        eq(agentRuns.agentName, agentName),
+        gte(agentRuns.startedAt, startOfDay)
+      )
+    )
+  return row?.total ?? 0
 }
 
 // ─── Stale-run watchdog (P2-005) ───────────────────────────────────

--- a/src/server/modules/slack/routes.ts
+++ b/src/server/modules/slack/routes.ts
@@ -30,11 +30,14 @@ export default buildStubRoutes({
     clientId: 'SLACK_CLIENT_ID',
     clientSecret: 'SLACK_CLIENT_SECRET',
   },
-  // Slack uses authorize v2 + oauth.v2.access for the exchange. Scopes
-  // live on `user_scope` for Sign in with Slack; `scope` is for bot.
-  // We request BOTH so the app is installed AND we get a user token.
+  // Slack uses authorize v2 + oauth.v2.access for the exchange. The scopes
+  // below are USER-token scopes, so they go on `user_scope` (not `scope`,
+  // which requests a bot token). oauth.v2.access then returns the user bearer
+  // at `authed_user.access_token`; the top-level `access_token` is the bot
+  // token, which we don't want — extractToken pulls the user bearer.
   authorizeEndpoint: 'https://slack.com/oauth/v2/authorize',
   tokenEndpoint: 'https://slack.com/api/oauth.v2.access',
+  scopeParam: 'user_scope',
   scopes: [
     'search:read',
     'channels:history',
@@ -43,6 +46,20 @@ export default buildStubRoutes({
     'users:read',
     'chat:write',
   ],
+  extractToken: (raw) => {
+    const j = raw as {
+      ok?: boolean
+      error?: string
+      authed_user?: { access_token?: string; scope?: string }
+    }
+    if (!j.ok || !j.authed_user?.access_token) {
+      throw new Error(`Slack OAuth failed: ${j.error ?? 'no user token in response'}`)
+    }
+    return {
+      access_token: j.authed_user.access_token,
+      ...(j.authed_user.scope ? { scope: j.authed_user.scope } : {}),
+    }
+  },
   fetchAccountInfo: async (token) => {
     // auth.test returns team + user info so we can show "Connected as <user> @ <team>".
     try {

--- a/tests/server/modules/routines/daily-budget.test.ts
+++ b/tests/server/modules/routines/daily-budget.test.ts
@@ -1,0 +1,126 @@
+/**
+ * #12 — per-routine dailyBudgetUsd enforcement in the scheduler.
+ *
+ * dailyBudgetUsd is stored on the routine but used to be ignored by the
+ * cron sweeper, so a runaway routine could spend without bound. The gate
+ * sums the routine agent's spend from agent_runs since UTC midnight and
+ * skips the fire once it reaches the cap.
+ *
+ * This verifies the security-relevant path: a due routine whose agent has
+ * already spent past its cap today is CONSIDERED but NOT FIRED, with no
+ * error. (We don't exercise the under-budget path here because that would
+ * actually invoke the target Durable Object.)
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { env } from 'cloudflare:test'
+import { processDueRoutines } from '@/server/modules/routines/scheduler'
+
+const USER_ID = 'test-user-budget'
+const AGENT_CLASS = 'AssistantAgent'
+const AGENT_NAME = 'budget-test-instance'
+
+async function runSql(sql: string, params: unknown[] = []): Promise<void> {
+  const stmt = env.DB.prepare(sql)
+  await (params.length > 0 ? stmt.bind(...params).run() : stmt.run())
+}
+
+async function ensureSchema(): Promise<void> {
+  await runSql(`CREATE TABLE IF NOT EXISTS routines (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    organization_id TEXT,
+    name TEXT NOT NULL,
+    description TEXT,
+    agent_class TEXT NOT NULL,
+    agent_name TEXT NOT NULL,
+    trigger_kind TEXT NOT NULL DEFAULT 'schedule',
+    trigger_config_json TEXT,
+    input_template_json TEXT,
+    tools_allowed_json TEXT,
+    skills_loaded_json TEXT,
+    hooks_json TEXT,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    base_interval INTEGER,
+    min_interval INTEGER,
+    max_interval INTEGER,
+    effective_interval INTEGER,
+    adjust_mode TEXT NOT NULL DEFAULT 'suggested',
+    daily_budget_usd REAL,
+    local_fire_hour INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    last_run_at INTEGER,
+    last_outcome TEXT
+  )`)
+  // Minimal agent_runs — only the columns the budget SUM query reads.
+  await runSql(`CREATE TABLE IF NOT EXISTS agent_runs (
+    id TEXT PRIMARY KEY,
+    agent_class TEXT NOT NULL,
+    agent_name TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    cost_usd REAL,
+    started_at INTEGER NOT NULL
+  )`)
+}
+
+async function insertDueRoutine(dailyBudgetUsd: number | null): Promise<void> {
+  const now = Math.floor(Date.now() / 1000)
+  await runSql(
+    `INSERT INTO routines (id, user_id, name, agent_class, agent_name, trigger_kind,
+       enabled, base_interval, effective_interval, daily_budget_usd, created_at, updated_at, last_run_at)
+     VALUES (?, ?, ?, ?, ?, 'schedule', 1, 900, 900, ?, ?, ?, NULL)`,
+    ['r-budget', USER_ID, 'Budget routine', AGENT_CLASS, AGENT_NAME, dailyBudgetUsd, now, now]
+  )
+}
+
+async function insertSpend(costUsd: number, startedAt: number): Promise<void> {
+  await runSql(
+    `INSERT INTO agent_runs (id, agent_class, agent_name, user_id, cost_usd, started_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [`run-${costUsd}-${startedAt}`, AGENT_CLASS, AGENT_NAME, USER_ID, costUsd, startedAt]
+  )
+}
+
+const baseEnv = () => env as unknown as { DB: D1Database }
+
+describe('routines scheduler — dailyBudgetUsd enforcement (#12)', () => {
+  beforeAll(async () => {
+    await ensureSchema()
+  })
+
+  beforeEach(async () => {
+    await runSql('DELETE FROM routines WHERE user_id = ?', [USER_ID])
+    await runSql('DELETE FROM agent_runs WHERE user_id = ?', [USER_ID])
+  })
+
+  it('skips a due routine whose agent is over its daily budget', async () => {
+    await insertDueRoutine(1.0)
+    const now = Math.floor(Date.now() / 1000)
+    // Two runs today summing to $1.20 — over the $1.00 cap.
+    await insertSpend(0.7, now - 60)
+    await insertSpend(0.5, now - 30)
+
+    const result = await processDueRoutines(baseEnv())
+    expect(result.considered).toBe(1)
+    expect(result.fired).toBe(0)
+    expect(result.errors).toBe(0)
+  })
+
+  it('does not count spend from before UTC midnight against today', async () => {
+    await insertDueRoutine(1.0)
+    const now = Math.floor(Date.now() / 1000)
+    const startOfDay = now - (now % 86400)
+    // $5 spent yesterday (just before midnight) must NOT block today.
+    await insertSpend(5.0, startOfDay - 120)
+    // Today's spend is $0, so the routine is under budget and the gate
+    // does NOT skip it — it proceeds to fire. We only assert the budget
+    // gate let it through (it was considered and not budget-skipped); the
+    // actual DO fire is environment-dependent, so we just check it wasn't
+    // blocked on budget grounds by confirming it was attempted.
+    const result = await processDueRoutines(baseEnv())
+    expect(result.considered).toBe(1)
+    // fired + errors === 1 means it got past the budget gate to the fire
+    // attempt (success or DO error), rather than being silently skipped.
+    expect(result.fired + result.errors).toBe(1)
+  })
+})


### PR DESCRIPTION
Closes the genuinely-live subset of the #95 quick-group. Verified each against current `main` first — **8 of 12 were already fixed** by #94/#96/#97/#98 (emailVerified gate, error handler, voice rate limit, PlaceMap scheme guard, msw cookie signing, mailgun region refactor, batch failedItems dedup, config-diff rename guard). The 4 below were live:

### #2 — DB-role admins unprotected (admin-vs-admin)
`admin/routes.ts` PATCH + DELETE only guarded env-allowlist admins (`isAdminEmail`). Added `role === 'admin'` so a panel-promoted admin can't be demoted/renamed/re-emailed/deleted by another admin. Revoke left unguarded for both admin types by design (emergency session-kill).

### #8 — admin-agent model id 404s on default deploy
`anthropic/claude-sonnet-4-6` (dash) only resolves on the direct-Anthropic path (resolver regex translates dot→dash there). On the **OpenRouter-only default deployment** it's forwarded verbatim and 404s. Changed to the catalogue/OpenRouter dot form `anthropic/claude-sonnet-4.6` (verified present in the live OpenRouter registry).

### #9 — Slack stored the bot token, not the user token
The shared stub-provider read top-level `access_token` (Slack's **bot** token) and requested scopes on `scope` (bot scopes). Slack's user bearer is at `authed_user.access_token`; user scopes go on `user_scope`. Added two optional stub-provider hooks (`scopeParam`, `extractToken`) and wired Slack to use them so the connector stores and acts as the user.

### #12 — routine dailyBudgetUsd never enforced
Stored on the routine but ignored by the cron sweeper. The scheduler now sums the routine agent's spend from `agent_runs` since UTC midnight and skips the fire once the cap is hit (cheap SUM per over-budget routine; unblocks after midnight). Regression test covers the over-budget skip + the before-midnight boundary.

---

- `pnpm type-check` ✅
- `pnpm test tests/server/modules/routines` ✅ (13 incl. new budget test)
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)