### PR TITLE
fix(security): polymorphic-entity access oracle — close comments/watchers IDOR (#95)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -52,6 +52,20 @@ so the two never drift. Org-scoped data is gated by membership via `getOrgRole()
 Never take a tenancy scope (`orgId`/`projectId`/`userId`) from a client query param;
 derive it from the session.
 
+### Polymorphic entities (comments, watchers, …)
+
+Features that attach to **any** entity by a client-supplied `entityType + entityId`
+pair can't use `scopeUser` (the row they're reading isn't the entity itself). They
+gate through `canAccessEntity(env, entityType, entityId, userId)`
+(`src/server/lib/entity-access.ts`) — the single oracle that resolves an entity's
+owner. It mirrors the `scopeUser` contract (per-user → owner match; shared → allow)
+and fails closed on unknown types or missing rows. The starter registers resolvers
+for `conversation`, `file`, and an entities-table fallback covering every
+`entities`-module type. **A fork that adds an entity type its comments/watchers
+attach to must `registerEntityType`/`registerEntityFallback` for it** — otherwise
+the gate denies (secure default). Without this oracle, any authed user reads/writes
+another tenant's comment threads and watch lists by id (polymorphic IDOR).
+
 ## 4. R2 object ownership
 
 R2 objects are stored under user-scoped key prefixes (`users/<userId>/…`). Any route

--- a/src/server/lib/entity-access.ts
+++ b/src/server/lib/entity-access.ts
@@ -1,0 +1,132 @@
+/**
+ * Entity-access oracle — the single "can this user touch this entity?" check
+ * for polymorphic features (comments, watchers, …) that act on an
+ * `entityType + entityId` pair taken from the request.
+ *
+ * The problem it solves: comments and watchers attach to ANY entity by
+ * (entityType, entityId). Without a generic ownership check, user A can read
+ * and write user B's comments/watchers by guessing/knowing B's entity ids
+ * (a polymorphic IDOR). A per-site patch gives false confidence — the class
+ * recurs the next time someone adds an entity-attached feature. This oracle
+ * is the one place that knows how to resolve an entity's owner, so every such
+ * site gates through `canAccessEntity` and the class is closed by construction.
+ *
+ * Contract (mirrors `scopeUser` in lib/tenancy.ts so the two never drift):
+ *   - shared-tenancy mode → always allow (records are shared by design)
+ *   - per-user mode       → the entity's owner userId must equal the caller
+ *
+ * Fail closed: an unregistered entity type with no fallback, or an entity
+ * that doesn't exist, returns false. Org-membership-based access is a
+ * deliberate later layer — v1 matches the userId-only semantics that
+ * `scopeUser` and the entities tool already use.
+ *
+ * Registration: a module that owns an entity type calls `registerEntityType`
+ * with a resolver that returns the entity's owner. The entities module stores
+ * many user-defined types (issue/task/…) in one table keyed by id, so it
+ * can't enumerate type strings — it registers a single `registerEntityFallback`
+ * that an entities-row lookup by id satisfies for any unmatched type.
+ */
+import { drizzle } from 'drizzle-orm/d1'
+import { eq } from 'drizzle-orm'
+import { isSharedTenancy } from '@/shared/config/tenancy'
+
+export interface EntityOwner {
+  userId: string
+  /** Reserved for org-membership access (a later layer). Unused in v1. */
+  organizationId?: string | null
+}
+
+export interface EntityAccessEnv {
+  DB: D1Database
+}
+
+/** Resolve an entity's owner, or null if it doesn't exist. */
+export type EntityAccessResolver = (
+  env: EntityAccessEnv,
+  entityId: string
+) => Promise<EntityOwner | null>
+
+const resolvers = new Map<string, EntityAccessResolver>()
+let fallbackResolver: EntityAccessResolver | null = null
+
+/** Register the owner-resolver for an exact entity type (e.g. 'conversation'). */
+export function registerEntityType(entityType: string, resolver: EntityAccessResolver): void {
+  resolvers.set(entityType, resolver)
+}
+
+/**
+ * Register a resolver tried when no exact type matches. The entities module
+ * uses this so its dynamic user-defined types (issue/task/…) are all covered
+ * by one entities-row lookup without enumerating type strings.
+ */
+export function registerEntityFallback(resolver: EntityAccessResolver): void {
+  fallbackResolver = resolver
+}
+
+let coreInstalled = false
+
+/**
+ * Install resolvers for the entity types the starter ships. Done lazily +
+ * once per isolate so the oracle is self-contained — callers don't depend on
+ * an import-for-side-effect running first. Forks add their own via
+ * registerEntityType / registerEntityFallback at module load.
+ */
+async function ensureCoreResolvers(): Promise<void> {
+  if (coreInstalled) return
+  coreInstalled = true
+  const { conversations } = await import('@/server/modules/conversations/db/schema')
+  const { files } = await import('@/server/modules/files/db/schema')
+  const { entities } = await import('@/server/modules/entities/db/schema')
+
+  registerEntityType('conversation', async (env, id) => {
+    const [row] = await drizzle(env.DB)
+      .select({ userId: conversations.userId })
+      .from(conversations)
+      .where(eq(conversations.id, id))
+      .limit(1)
+    return row ? { userId: row.userId } : null
+  })
+
+  registerEntityType('file', async (env, id) => {
+    const [row] = await drizzle(env.DB)
+      .select({ userId: files.userId })
+      .from(files)
+      .where(eq(files.id, id))
+      .limit(1)
+    return row ? { userId: row.userId } : null
+  })
+
+  // Fallback: the generic entities store keys every type (issue/task/custom)
+  // by id, owned by userId (+ optional organizationId). Covers any entityType
+  // that doesn't have an exact resolver.
+  registerEntityFallback(async (env, id) => {
+    const [row] = await drizzle(env.DB)
+      .select({ userId: entities.userId, organizationId: entities.organizationId })
+      .from(entities)
+      .where(eq(entities.id, id))
+      .limit(1)
+    return row ? { userId: row.userId, organizationId: row.organizationId } : null
+  })
+}
+
+/**
+ * Can `userId` access the entity identified by (entityType, entityId)?
+ *
+ * Returns false (deny) for unknown types or missing entities — fail closed.
+ * Use at every request boundary that reads/writes by a client-supplied
+ * entityType + entityId.
+ */
+export async function canAccessEntity(
+  env: EntityAccessEnv,
+  entityType: string,
+  entityId: string,
+  userId: string
+): Promise<boolean> {
+  if (isSharedTenancy) return true
+  await ensureCoreResolvers()
+  const resolver = resolvers.get(entityType) ?? fallbackResolver
+  if (!resolver) return false
+  const owner = await resolver(env, entityId)
+  if (!owner) return false
+  return owner.userId === userId
+}

--- a/src/server/modules/chat/tools/batch-task.ts
+++ b/src/server/modules/chat/tools/batch-task.ts
@@ -26,6 +26,7 @@ import { and, eq, inArray, or } from 'drizzle-orm'
 import { files as filesTable } from '@/server/modules/files/db/schema'
 import { createJob } from '@/server/modules/batch-tasks/storage'
 import { batchJobs } from '@/server/modules/batch-tasks/db/schema'
+import { isOwnedR2Key } from '@/server/lib/r2-keys'
 import type { ToolDefinition, AgentContext } from '@/shared/agent'
 import type { BatchWorkflowParams } from '@/server/modules/batch-tasks/workflows/process-batch'
 
@@ -135,9 +136,16 @@ async function resolveR2Keys(
 
   for (const ref of refs) {
     const row = byId.get(ref) ?? byName.get(ref) ?? byKey.get(ref)
-    // Last resort: assume the agent already passed a bare R2 key. The
-    // Workflow will surface "R2 object not found" if that's wrong.
-    out.set(ref, row ? { key: row.key, label: row.name } : { key: ref })
+    if (row) {
+      out.set(ref, { key: row.key, label: row.name })
+    } else if (isOwnedR2Key(ref, userId)) {
+      // The agent passed a bare R2 key that belongs to this user — accept it.
+      // isOwnedR2Key gates this so a crafted key under another user's prefix
+      // can't be loaded by the batch Workflow (cross-user R2 read).
+      out.set(ref, { key: ref })
+    }
+    // else: unknown ref, or a bare key owned by someone else — left
+    // unresolved so the caller rejects the job rather than reading it.
   }
   return out
 }
@@ -163,14 +171,30 @@ export const startBatchTaskDefinition: ToolDefinition<
     const r2Refs = input.items.filter((it) => it.ref_kind === 'r2_file').map((it) => it.ref_value)
     const resolved = await resolveR2Keys(env.DB, ctx.userId, r2Refs)
 
+    // Fail closed on any r2_file ref that didn't resolve to a file the caller
+    // owns (unknown ref, or a bare key under another user's prefix). Rejecting
+    // up front beats silently passing a foreign key to the Workflow.
+    const unresolved = [
+      ...new Set(
+        input.items
+          .filter((it) => it.ref_kind === 'r2_file' && !resolved.has(it.ref_value))
+          .map((it) => it.ref_value)
+      ),
+    ]
+    if (unresolved.length > 0) {
+      const shown = unresolved.slice(0, 10).join(', ')
+      const more = unresolved.length > 10 ? ` (+${unresolved.length - 10} more)` : ''
+      return {
+        ok: false as const,
+        error: `These file references don't match any of your files: ${shown}${more}. Pass a filename, the file's id, or an R2 key you own.`,
+      }
+    }
+
     const items = input.items.map((it) => {
       if (it.ref_kind !== 'r2_file') {
         return { ref_kind: it.ref_kind, ref_value: it.ref_value, label: it.label }
       }
-      const r = resolved.get(it.ref_value)
-      if (!r) {
-        return { ref_kind: it.ref_kind as 'r2_file', ref_value: it.ref_value, label: it.label }
-      }
+      const r = resolved.get(it.ref_value)!
       return { ref_kind: 'r2_file' as const, ref_value: r.key, label: it.label ?? r.label }
     })
 

--- a/src/server/modules/comments/routes.ts
+++ b/src/server/modules/comments/routes.ts
@@ -13,6 +13,7 @@ import { authMiddleware, type AuthContext } from '@/server/middleware/auth'
 import { comments } from './db/schema'
 import { user } from '@/server/modules/auth/db/schema'
 import { whereNotDeleted, softDeleteValues } from '@/server/lib/soft-delete'
+import { canAccessEntity } from '@/server/lib/entity-access'
 
 const app = new Hono<AuthContext>()
 app.use('*', authMiddleware)
@@ -29,6 +30,12 @@ app.get('/', async (c) => {
   const entityType = c.req.query('entityType')
   const entityId = c.req.query('entityId')
   if (!entityType || !entityId) return c.json({ error: 'entityType and entityId required' }, 400)
+
+  // Gate: only list comments on an entity the caller can access. Without this
+  // any authed user could read any entity's comment thread by its id (IDOR).
+  if (!(await canAccessEntity(c.env, entityType, entityId, c.get('userId')))) {
+    return c.json({ error: 'Not found' }, 404)
+  }
 
   const db = drizzle(c.env.DB)
   const rows = await db
@@ -73,6 +80,12 @@ app.post(
   async (c) => {
     const input = c.req.valid('json')
     const userId = c.get('userId')
+
+    // Gate: only comment on an entity the caller can access (IDOR-write guard).
+    if (!(await canAccessEntity(c.env, input.entityType, input.entityId, userId))) {
+      return c.json({ error: 'Not found' }, 404)
+    }
+
     const db = drizzle(c.env.DB)
 
     const [comment] = await db

--- a/src/server/modules/watchers/routes.ts
+++ b/src/server/modules/watchers/routes.ts
@@ -12,6 +12,7 @@ import { drizzle } from 'drizzle-orm/d1'
 import { eq, and } from 'drizzle-orm'
 import { authMiddleware, type AuthContext } from '@/server/middleware/auth'
 import { watchers } from './db/schema'
+import { canAccessEntity } from '@/server/lib/entity-access'
 
 const app = new Hono<AuthContext>()
 app.use('*', authMiddleware)
@@ -23,6 +24,10 @@ app.get('/', async (c) => {
   if (!entityType || !entityId) return c.json({ error: 'entityType and entityId required' }, 400)
 
   const userId = c.get('userId')
+  // Gate: don't reveal who watches an entity the caller can't access (IDOR).
+  if (!(await canAccessEntity(c.env, entityType, entityId, userId))) {
+    return c.json({ error: 'Not found' }, 404)
+  }
   const db = drizzle(c.env.DB)
 
   const rows = await db
@@ -44,6 +49,10 @@ app.post(
   async (c) => {
     const { entityType, entityId } = c.req.valid('json')
     const userId = c.get('userId')
+    // Gate: can't subscribe to (and get notified about) an inaccessible entity.
+    if (!(await canAccessEntity(c.env, entityType, entityId, userId))) {
+      return c.json({ error: 'Not found' }, 404)
+    }
     const db = drizzle(c.env.DB)
 
     await db.insert(watchers).values({ entityType, entityId, userId }).onConflictDoNothing()

--- a/tests/server/lib/entity-access.test.ts
+++ b/tests/server/lib/entity-access.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Entity-access oracle (#95 polymorphic-IDOR capstone).
+ *
+ * Verifies the contract that comments + watchers gate through:
+ *   - owner can access their own entity (exact resolver + fallback paths)
+ *   - a different user is denied
+ *   - a missing entity is denied (fail closed)
+ *   - an unregistered type with no fallback hit is denied
+ *
+ * Runs in the default per-user tenancy mode (VITE_TENANCY_MODE unset).
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { env } from 'cloudflare:test'
+import { canAccessEntity } from '@/server/lib/entity-access'
+
+const OWNER = 'user-owner'
+const OTHER = 'user-other'
+
+async function runSql(sql: string, params: unknown[] = []): Promise<void> {
+  const stmt = env.DB.prepare(sql)
+  await (params.length > 0 ? stmt.bind(...params).run() : stmt.run())
+}
+
+async function ensureSchema(): Promise<void> {
+  // Minimal shapes — only the columns the resolvers SELECT.
+  await runSql(`CREATE TABLE IF NOT EXISTS entities (
+    id TEXT PRIMARY KEY, user_id TEXT NOT NULL, organization_id TEXT, type TEXT NOT NULL
+  )`)
+  await runSql(`CREATE TABLE IF NOT EXISTS conversations (
+    id TEXT PRIMARY KEY, user_id TEXT NOT NULL
+  )`)
+  await runSql(`CREATE TABLE IF NOT EXISTS files (
+    id TEXT PRIMARY KEY, userId TEXT NOT NULL
+  )`)
+}
+
+const baseEnv = () => env as unknown as { DB: D1Database }
+
+describe('entity-access oracle — canAccessEntity (#95)', () => {
+  beforeAll(async () => {
+    await ensureSchema()
+    await runSql(`INSERT OR REPLACE INTO entities (id, user_id, type) VALUES ('ent-1', ?, 'issue')`, [
+      OWNER,
+    ])
+    await runSql(`INSERT OR REPLACE INTO conversations (id, user_id) VALUES ('conv-1', ?)`, [OWNER])
+  })
+
+  it('allows the owner (entities fallback resolver, dynamic type)', async () => {
+    expect(await canAccessEntity(baseEnv(), 'issue', 'ent-1', OWNER)).toBe(true)
+  })
+
+  it('denies a different user on the same entity (IDOR blocked)', async () => {
+    expect(await canAccessEntity(baseEnv(), 'issue', 'ent-1', OTHER)).toBe(false)
+  })
+
+  it('allows the owner via the exact conversation resolver', async () => {
+    expect(await canAccessEntity(baseEnv(), 'conversation', 'conv-1', OWNER)).toBe(true)
+  })
+
+  it('denies a different user on a conversation', async () => {
+    expect(await canAccessEntity(baseEnv(), 'conversation', 'conv-1', OTHER)).toBe(false)
+  })
+
+  it('denies a missing entity (fail closed)', async () => {
+    expect(await canAccessEntity(baseEnv(), 'issue', 'does-not-exist', OWNER)).toBe(false)
+  })
+})


### PR DESCRIPTION
The #95 *"needs a shared contract"* cluster. comments, watchers, and the batch `r2_file` ref path acted on a client-supplied `entityType + entityId` with **no ownership check**, so any authed user could read/write another tenant's comment threads + watch lists by id (polymorphic IDOR). #95 explicitly flagged that a per-site patch gives false confidence — so this introduces the shared oracle and gates every site through it.

## New contract — `src/server/lib/entity-access.ts`
`canAccessEntity(env, entityType, entityId, userId)` — a registry of per-type owner-resolvers plus a fallback. Mirrors `scopeUser` (per-user → owner match; shared-tenancy → allow). **Fails closed** on unknown type / missing entity.

- `registerEntityType` / `registerEntityFallback` for forks to extend.
- Core resolvers shipped: `conversation`, `file`, and an **entities-table fallback** that covers every dynamic entities-module type (`issue`/`task`/custom) by id — the entities store can't enumerate its user-defined type strings, so a fallback is the right shape.

## Gated sites
- **comments** GET + POST → require entity access (404 otherwise)
- **watchers** GET + POST → require entity access
- **batch-task `r2_file`** → bare-key fallback now requires `isOwnedR2Key`; a ref that doesn't resolve to a file the caller owns is rejected up front instead of passed verbatim to the Workflow (cross-user R2 read)

The entities chat tool already scoped by `userId` — left as is. Org-membership access is a deliberate later layer (v1 = userId-only, matching `scopeUser`).

`docs/SECURITY.md` §3 documents the oracle + the fork-registration requirement.

---
- `pnpm type-check` ✅
- `pnpm test tests/server/lib/entity-access.test.ts` ✅ (5: owner-allow, cross-user-deny ×2, fallback, fail-closed)
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)