### PR TITLE
fix(security): login-gate fail mode + R2 key guard + routine slug (automated review)

### DIFF
--- a/src/server/lib/r2-keys.ts
+++ b/src/server/lib/r2-keys.ts
@@ -25,6 +25,12 @@ export function ownedR2Prefixes(userId: string): string[] {
  */
 export function isOwnedR2Key(key: string | undefined | null, userId: string): boolean {
   if (!key) return false
+  // R2 is a flat keyspace (no path traversal), so the prefix check below is
+  // already sufficient — but reject `.`/`..`/empty segments, leading slashes
+  // and backslashes anyway as defense-in-depth, so no caller that normalises
+  // the key (or a future store with directory semantics) can escape the prefix.
+  if (key.startsWith('/') || key.includes('\\')) return false
+  if (key.split('/').some((seg) => seg === '' || seg === '.' || seg === '..')) return false
   if (isSharedTenancy) return /^(users|generated|files)\/[^/]+\//.test(key)
   return ownedR2Prefixes(userId).some((p) => key.startsWith(p))
 }

--- a/src/server/modules/auth/index.ts
+++ b/src/server/modules/auth/index.ts
@@ -97,6 +97,30 @@ export function isSignupAllowed(
   return !!domain && domains.has(domain)
 }
 
+/**
+ * Is an allowlist actually configured? When false the app accepts any signup
+ * (public-starter default), so error paths in the login gate may fail OPEN
+ * without widening access. When true the gate is load-bearing, so those same
+ * error paths must fail CLOSED — a transient D1 error must not re-admit a
+ * pre-existing account the operator has since removed from the allowlist.
+ */
+export function isAllowlistActive(cfg: {
+  ALLOWED_AUTH_EMAILS?: string
+  ALLOWED_AUTH_DOMAINS?: string
+  AUTH_ALLOWLIST?: string
+}): boolean {
+  const has = (raw?: string) =>
+    (raw ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean).length > 0
+  return (
+    String(cfg.AUTH_ALLOWLIST ?? '').toLowerCase() === 'true' ||
+    has(cfg.ALLOWED_AUTH_EMAILS) ||
+    has(cfg.ALLOWED_AUTH_DOMAINS)
+  )
+}
+
 export function createAuthFromEnv(d1: D1Database, env: Record<string, unknown>) {
   return createAuth(d1, {
     BETTER_AUTH_SECRET: String(env['BETTER_AUTH_SECRET'] ?? ''),
@@ -323,20 +347,26 @@ export function createAuth(
                 .bind(newSession.userId)
                 .first()) as { email?: string } | null
               const email = typeof row?.email === 'string' ? row.email : ''
-              if (email && !isSignupAllowed(email, env)) {
+              // When the allowlist is active, fail CLOSED on both a disallowed
+              // AND an unresolvable email — an existing-but-now-disallowed
+              // account (or one whose email row can't be read) must not log in.
+              // When the gate is off, isAllowlistActive is false and we never
+              // block here (public-signup forks).
+              if (isAllowlistActive(env) && (!email || !isSignupAllowed(email, env))) {
                 console.warn(JSON.stringify({ event: 'auth_login_blocked', email }))
                 return false
               }
             } catch (err) {
-              // Fail OPEN on a lookup error rather than lock everyone out on a
-              // transient D1 blip — new intruders are already blocked at
-              // user.create.before; this hook only catches pre-existing ones.
               console.error(
                 JSON.stringify({
                   event: 'auth_login_gate_error',
                   error: err instanceof Error ? err.message : String(err),
                 })
               )
+              // Fail CLOSED when an allowlist is active (a transient D1 error
+              // must not re-admit a removed account); fail OPEN when no
+              // allowlist is configured, so a blip can't lock out a public fork.
+              if (isAllowlistActive(env)) return false
             }
             return { data: newSession }
           },

--- a/src/server/modules/routines/routes.ts
+++ b/src/server/modules/routines/routes.ts
@@ -40,8 +40,19 @@ import { routineRuns } from './db/schema'
  * without this, a user could set agentName to `<victimId>:slug` and have the
  * cron fire collide with / overwrite the owner of another tenant's agent DO.
  */
-function ownerScopedAgentName(userId: string, agentName: string): string {
+/** Agent-instance slug charset — kebab/snake identifiers only. Keeps DO
+ *  instance names clean and rejects malformed input early. */
+const AGENT_SLUG_RE = /^[A-Za-z0-9_-]{1,64}$/
+
+/**
+ * Returns the owner-namespaced DO instance name, or null if the slug is
+ * malformed. Cross-tenant targeting is already impossible — the slug is always
+ * re-prefixed with the CALLER's userId — but we still validate the slug so
+ * DO instance names stay well-formed (defense-in-depth; #95 follow-up).
+ */
+function ownerScopedAgentName(userId: string, agentName: string): string | null {
   const slug = agentName.includes(':') ? agentName.slice(agentName.indexOf(':') + 1) : agentName
+  if (!AGENT_SLUG_RE.test(slug)) return null
   return `${userId}:${slug}`
 }
 
@@ -96,13 +107,17 @@ app.post('/', zValidator('json', CreateSchema), async (c) => {
   if (!getAgentMetadata(body['agentClass'])) {
     return c.json({ error: `Unknown agent class: ${body['agentClass']}` }, 400)
   }
+  const scopedName = ownerScopedAgentName(userId, body['agentName'])
+  if (!scopedName) {
+    return c.json({ error: 'Invalid agentName — use letters, numbers, _ or - (max 64)' }, 400)
+  }
   const created = await createRoutine(c.env, {
     userId,
     organizationId: orgId,
     name: body['name'],
     ...(body['description'] !== undefined ? { description: body['description'] } : {}),
     agentClass: body['agentClass'],
-    agentName: ownerScopedAgentName(userId, body['agentName']),
+    agentName: scopedName,
     triggerKind: body['triggerKind'],
     ...(body['triggerConfig'] !== undefined ? { triggerConfig: body['triggerConfig'] } : {}),
     ...(body['inputTemplate'] !== undefined ? { inputTemplate: body['inputTemplate'] } : {}),
@@ -139,7 +154,11 @@ app.patch('/:id', zValidator('json', PatchSchema), async (c) => {
     return c.json({ error: `Unknown agent class: ${patch['agentClass']}` }, 400)
   }
   if (patch['agentName'] !== undefined) {
-    patch['agentName'] = ownerScopedAgentName(userId, patch['agentName'])
+    const scopedName = ownerScopedAgentName(userId, patch['agentName'])
+    if (!scopedName) {
+      return c.json({ error: 'Invalid agentName — use letters, numbers, _ or - (max 64)' }, 400)
+    }
+    patch['agentName'] = scopedName
   }
   const updated = await updateRoutine(c.env, c.req.param('id'), userId, patch, orgId)
   if (!updated) return c.json({ error: 'Not found' }, 404)

--- a/tests/server/lib/r2-keys.test.ts
+++ b/tests/server/lib/r2-keys.test.ts
@@ -1,0 +1,41 @@
+/**
+ * isOwnedR2Key — cross-tenant + traversal guard (security-review follow-up).
+ *
+ * Default per-user tenancy mode (VITE_TENANCY_MODE unset). Confirms the
+ * prefix gate plus the defensive rejection of `..`/empty segments, leading
+ * slashes and backslashes that images/media/files routes rely on.
+ */
+import { describe, expect, it } from 'vitest'
+import { isOwnedR2Key } from '@/server/lib/r2-keys'
+
+const ME = 'user-me'
+
+describe('isOwnedR2Key (per-user mode)', () => {
+  it('allows the caller’s own scoped keys', () => {
+    expect(isOwnedR2Key(`users/${ME}/photo.jpg`, ME)).toBe(true)
+    expect(isOwnedR2Key(`generated/${ME}/out.png`, ME)).toBe(true)
+    expect(isOwnedR2Key(`files/${ME}/doc.pdf`, ME)).toBe(true)
+  })
+
+  it('denies another tenant’s keys', () => {
+    expect(isOwnedR2Key('users/user-victim/photo.jpg', ME)).toBe(false)
+  })
+
+  it('denies prefix-confusion (me vs me2)', () => {
+    expect(isOwnedR2Key('users/user-me2/secret.jpg', ME)).toBe(false)
+  })
+
+  it('rejects empty / nullish / unscoped keys', () => {
+    expect(isOwnedR2Key('', ME)).toBe(false)
+    expect(isOwnedR2Key(null, ME)).toBe(false)
+    expect(isOwnedR2Key('random-key', ME)).toBe(false)
+  })
+
+  it('rejects traversal-style and malformed keys even under the right prefix', () => {
+    expect(isOwnedR2Key(`users/${ME}/../user-victim/x.jpg`, ME)).toBe(false)
+    expect(isOwnedR2Key(`users/${ME}/./x.jpg`, ME)).toBe(false)
+    expect(isOwnedR2Key(`users/${ME}//x.jpg`, ME)).toBe(false) // empty segment
+    expect(isOwnedR2Key(`/users/${ME}/x.jpg`, ME)).toBe(false) // leading slash
+    expect(isOwnedR2Key(`users\\${ME}\\x.jpg`, ME)).toBe(false) // backslashes
+  })
+})

--- a/tests/server/signup-allowlist.test.ts
+++ b/tests/server/signup-allowlist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isSignupAllowed } from '@/server/modules/auth'
+import { isSignupAllowed, isAllowlistActive } from '@/server/modules/auth'
 
 describe('signup allowlist gate (#88)', () => {
   it('is inactive by default → allows everyone (public-starter default)', () => {
@@ -59,6 +59,19 @@ describe('signup allowlist gate (#88)', () => {
       const cfg = { ALLOWED_AUTH_DOMAINS: 'acme.com', TEST_AUTH_TOKEN: 'secret' }
       expect(isSignupAllowed('alice@test.acme.com', cfg)).toBe(false) // not .local
       expect(isSignupAllowed('alice@nottest.foo.local', cfg)).toBe(false) // not test.*
+    })
+  })
+
+  // Drives the login-gate fail-open-vs-closed decision (session.create.before).
+  describe('isAllowlistActive (login-gate fail mode)', () => {
+    it('is false when no allowlist is configured → error paths fail OPEN', () => {
+      expect(isAllowlistActive({})).toBe(false)
+      expect(isAllowlistActive({ ALLOWED_AUTH_EMAILS: '', ALLOWED_AUTH_DOMAINS: '  ' })).toBe(false)
+    })
+    it('is true when any allowlist mechanism is set → error paths fail CLOSED', () => {
+      expect(isAllowlistActive({ ALLOWED_AUTH_EMAILS: 'a@b.com' })).toBe(true)
+      expect(isAllowlistActive({ ALLOWED_AUTH_DOMAINS: 'acme.com' })).toBe(true)
+      expect(isAllowlistActive({ AUTH_ALLOWLIST: 'true' })).toBe(true)
     })
   })
 })


### PR DESCRIPTION
Automated security review follow-ups on the access-control work. Each verified against the actual code before changing:

### 1. [HIGH] auth `session.create.before` fail-OPEN — **fixed**
The login re-check returned the session on a D1 lookup error *and* on an unresolvable email, so a transient error could re-admit a pre-existing account the operator removed from the allowlist. Now fails **CLOSED** on both paths **when an allowlist is active** (new `isAllowlistActive` helper) and still fails **OPEN** when no allowlist is configured (a D1 blip mustn't lock out a public-signup fork). `user.create.before` was already closed.

### 2. [MED] routines `ownerScopedAgentName` — **hardened (not an IDOR)**
The flagged cross-tenant targeting doesn't hold: the slug is always re-prefixed with the **caller's** `userId`, so a DO can't address another tenant. Added strict slug validation (`^[A-Za-z0-9_-]{1,64}$`) in POST + PATCH anyway — defense-in-depth + well-formed DO instance names.

### 3. [MED] images/media R2 reads — **already mitigated; primitive hardened**
Already gated by `isOwnedR2Key`'s strict `users/<userId>/` prefix (the trailing slash blocks `me` vs `me2` confusion; R2 is a flat keyspace so `..` isn't path traversal). Hardened the single `isOwnedR2Key` primitive to also reject `.`/`..`/empty segments, leading slashes and backslashes — one change covers images, media, **and** files.

---
- `pnpm type-check` ✅
- `pnpm test signup-allowlist + r2-keys` ✅ (17: `isAllowlistActive` fail-mode + `isOwnedR2Key` traversal/prefix-confusion)
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)