### PR TITLE
fix(chat): approval buttons dead under Workers AI models (#119)

### DIFF
--- a/src/client/modules/chat/components/ChatMessage.tsx
+++ b/src/client/modules/chat/components/ChatMessage.tsx
@@ -26,6 +26,10 @@ interface ChatMessageProps {
   onRegenerate?: () => void
   onSendMessage?: (text: string) => void
   onToolApproval?: (params: {
+    /** The SDK matches approval responses on `approval.id`, NOT `toolCallId`.
+     * They coincide on most providers, but Workers AI decorates toolCallId
+     * (`functions.<name>:N::cf-wai-tool-call::<id>`) so the two diverge (#119). */
+    approvalId: string
     toolCallId: string
     toolName: string
     result: 'approve' | 'deny'
@@ -122,6 +126,11 @@ export const ChatMessage = memo(function ChatMessage({
                           args={(p['input'] as Record<string, unknown>) ?? {}}
                           onApprove={() =>
                             onToolApproval({
+                              // approval.id, not toolCallId — see #119
+                              approvalId: String(
+                                (p['approval'] as { id?: string } | undefined)?.id ??
+                                  p['toolCallId']
+                              ),
                               toolCallId: String(p['toolCallId']),
                               toolName,
                               result: 'approve',
@@ -129,6 +138,10 @@ export const ChatMessage = memo(function ChatMessage({
                           }
                           onDeny={() =>
                             onToolApproval({
+                              approvalId: String(
+                                (p['approval'] as { id?: string } | undefined)?.id ??
+                                  p['toolCallId']
+                              ),
                               toolCallId: String(p['toolCallId']),
                               toolName,
                               result: 'deny',

--- a/src/client/modules/chat/components/MessageRenderer.tsx
+++ b/src/client/modules/chat/components/MessageRenderer.tsx
@@ -41,6 +41,10 @@ interface Props {
   /** Edit a user message and regenerate from that point. */
   onEdit?: (messageId: string, newText: string) => void
   onToolApproval?: (params: {
+    /** The SDK matches approval responses on `approval.id`, NOT `toolCallId`.
+     * They coincide on most providers, but Workers AI decorates toolCallId
+     * (`functions.<name>:N::cf-wai-tool-call::<id>`) so the two diverge (#119). */
+    approvalId: string
     toolCallId: string
     toolName: string
     result: 'approve' | 'deny'
@@ -297,6 +301,10 @@ function MessageBody({
   isLast?: boolean
   onSendMessage?: (text: string) => void
   onToolApproval?: (params: {
+    /** The SDK matches approval responses on `approval.id`, NOT `toolCallId`.
+     * They coincide on most providers, but Workers AI decorates toolCallId
+     * (`functions.<name>:N::cf-wai-tool-call::<id>`) so the two diverge (#119). */
+    approvalId: string
     toolCallId: string
     toolName: string
     result: 'approve' | 'deny'
@@ -476,6 +484,11 @@ function MessageBody({
 
           // 4a. Tool approval requested — our custom approval UI
           if (state === 'approval-requested' && onToolApproval) {
+            // approval.id is what addToolApprovalResponse matches on; fall back
+            // to toolCallId for providers where the SDK sets them equal (#119)
+            const approvalId = String(
+              (p['approval'] as { id?: string } | undefined)?.id ?? p['toolCallId']
+            )
             return (
               <ToolApproval
                 key={i}
@@ -483,13 +496,19 @@ function MessageBody({
                 args={(p['input'] as Record<string, unknown>) ?? {}}
                 onApprove={() =>
                   onToolApproval({
+                    approvalId,
                     toolCallId: String(p['toolCallId']),
                     toolName,
                     result: 'approve',
                   })
                 }
                 onDeny={() =>
-                  onToolApproval({ toolCallId: String(p['toolCallId']), toolName, result: 'deny' })
+                  onToolApproval({
+                    approvalId,
+                    toolCallId: String(p['toolCallId']),
+                    toolName,
+                    result: 'deny',
+                  })
                 }
               />
             )

--- a/src/client/modules/chat/pages/ChatPage.tsx
+++ b/src/client/modules/chat/pages/ChatPage.tsx
@@ -403,14 +403,18 @@ function ChatPageInner({ userId }: { userId: string }) {
 
   const handleToolApproval = useCallback(
     ({
-      toolCallId,
+      approvalId,
       result,
     }: {
+      approvalId: string
       toolCallId: string
       toolName: string
       result: 'approve' | 'deny'
     }) => {
-      addToolApprovalResponse({ id: toolCallId, approved: result === 'approve' })
+      // Must be approval.id, not toolCallId — the SDK's
+      // addToolApprovalResponse matches on the part's approval.id, and
+      // Workers AI decorates toolCallId so the two diverge there (#119)
+      addToolApprovalResponse({ id: approvalId, approved: result === 'approve' })
     },
     [addToolApprovalResponse]
   )


### PR DESCRIPTION
## What

Implements the fix verified in #119: `ChatPage.handleToolApproval` passed `toolCallId` to `addToolApprovalResponse`, but the agents SDK matches on the part's `approval.id`. The two coincide on most providers — Workers AI decorates `toolCallId` (`functions.<name>:N::cf-wai-tool-call::<id>`), so approvals silently no-opped there.

- `MessageRenderer` approval branch extracts `approval.id ?? toolCallId` and threads it through `onToolApproval` as a new explicit `approvalId` param (with a doc comment on why the two ids differ)
- `ChatPage.handleToolApproval` uses `approvalId` for `addToolApprovalResponse`
- `ChatMessage.tsx` gets the identical fix — it's currently imported nowhere (dead code, only `MessageRenderer` renders messages), but it carries the same copy-paste-able bug. Flagging: worth a follow-up decision on deleting it.

This matches the already-working pattern in `ThinkPilotPage` (passes `approval.id` via the SDK's `getToolApproval`).

## Verified

- 291/291 unit tests, type-check clean, lint no new issues
- **Not live-verified under a Workers AI model** — no `TEST_AUTH_TOKEN` available on this machine for an authed session. The identical diff was live-verified by the issue reporter on their fork (goanna-wiki). Happy to live-verify once a test session is possible.

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)