### PR TITLE
chore(models): resolve 6 stale catalogue model IDs (#121)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -305,7 +305,7 @@ formatting rules, domain context, and guardrails. Skills like
 ```typescript
 const result = await agent.runOnce({
   input: 'What's on my calendar tomorrow?',
-  model: 'anthropic/claude-sonnet-4.6',  // optional override
+  model: 'anthropic/claude-sonnet-5',  // optional override
   maxSteps: 5,                           // tool-call cap
 })
 // → { text, usage: {inputTokens, outputTokens}, steps }
@@ -324,7 +324,7 @@ export class MyAssistant extends AutonomousAgent<Env, AutonomousAgentState> {
   initialState = {
     ...AutonomousAgent.defaultInitialState(),
     persona: 'You are a research helper for...',
-    modelId: 'anthropic/claude-sonnet-4.6',
+    modelId: 'anthropic/claude-sonnet-5',
   }
 
   // Tool catalog. Default is []. Reuse the chat module's tool

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -132,7 +132,7 @@ return createAgentUIStreamResponse({
 import { useChat } from '@/client/modules/chat/hooks/useChat'
 
 const { messages, sendMessage, isLoading } = useChat({
-  model: 'anthropic/claude-sonnet-4.6',
+  model: 'anthropic/claude-sonnet-5',
   conversationId: urlConversationId,
 })
 sendMessage({ text: 'Hello' })

--- a/src/server/lib/ai/models.ts
+++ b/src/server/lib/ai/models.ts
@@ -8,7 +8,7 @@
  *
  * Model IDs:
  * - `@cf/...`   → Workers AI (free, no key)
- * - `provider/model` (e.g. `anthropic/claude-sonnet-4.6`) → OpenRouter
+ * - `provider/model` (e.g. `anthropic/claude-sonnet-5`) → OpenRouter
  *   (requires OPENROUTER_API_KEY)
  */
 import type { ModelId, ModelConfig, ModelTier } from './types'
@@ -148,15 +148,16 @@ export const ALIAS_TO_MODEL_ID: Record<string, ModelId> = {
   glm: '@cf/zai-org/glm-4.7-flash',
   qwq: '@cf/qwen/qwq-32b',
   opus: 'anthropic/claude-opus-4.8',
-  sonnet: 'anthropic/claude-sonnet-4.6',
+  sonnet: 'anthropic/claude-sonnet-5',
   haiku: 'anthropic/claude-haiku-4.5',
-  gpt: 'openai/gpt-5.4',
+  gpt: 'openai/gpt-5.5',
   'gpt-mini': 'openai/gpt-5.4-mini',
   gemini: 'google/gemini-3.1-pro-preview',
   'gemini-flash': 'google/gemini-3-flash-preview',
-  deepseek: 'deepseek/deepseek-v4-pro',
-  qwen: 'qwen/qwen3.6-plus',
-  grok: 'x-ai/grok-4.20',
+  deepseek: 'deepseek/deepseek-v4-flash-0731',
+  'kimi-k3': 'moonshotai/kimi-k3',
+  qwen: 'qwen/qwen3.7-plus',
+  grok: 'x-ai/grok-4.5',
   mistral: 'mistralai/mistral-large-2512',
 }
 

--- a/src/server/lib/ai/providers.ts
+++ b/src/server/lib/ai/providers.ts
@@ -180,7 +180,7 @@ export async function resolveModelForUser(
  */
 function tryDirectFromPrefix(env: ProviderEnv, modelId: string) {
   if (modelId.startsWith('anthropic/') && env.ANTHROPIC_API_KEY) {
-    // Catalogue IDs use OpenRouter's dot format (`claude-sonnet-4.6`).
+    // Catalogue IDs use OpenRouter's dot format (`claude-sonnet-5`).
     // Anthropic's direct API rejects dots — it wants dashes (`claude-sonnet-4-6`).
     // Translate on the direct path; OpenRouter route still receives the
     // dotted form unchanged. See gh #58.

--- a/src/server/lib/gateway/providers.ts
+++ b/src/server/lib/gateway/providers.ts
@@ -300,9 +300,9 @@ export const PROVIDER_REGISTRY: Record<ExternalProvider, ExternalProviderConfig>
         description: 'GPT-4o through OpenRouter',
       },
       {
-        id: 'anthropic/claude-sonnet-4.6',
-        name: 'Claude Sonnet 4.6 (via OpenRouter)',
-        contextWindow: 200000,
+        id: 'anthropic/claude-sonnet-5',
+        name: 'Claude Sonnet 5 (via OpenRouter)',
+        contextWindow: 1000000,
         maxOutputTokens: 64000,
         supportsStreaming: true,
         supportsVision: true,

--- a/src/server/modules/autonomous-agents/admin-agent.ts
+++ b/src/server/modules/autonomous-agents/admin-agent.ts
@@ -90,12 +90,12 @@ export class AdminAgent extends AutonomousAgent<Env, AutonomousAgentState> {
     // worth the marginal cost. Forks can override via setState if they
     // want Haiku for cost.
     //
-    // Catalogue/OpenRouter id format uses a DOT (`claude-sonnet-4.6`).
+    // Catalogue/OpenRouter id format uses a DOT (`claude-sonnet-5`).
     // The dash form (`4-6`) is only the direct-Anthropic SDK spelling, which
     // resolveModel derives via regex on the direct path. On the default
     // OpenRouter-only deployment the dash form is forwarded verbatim and 404s
     // ("model not found"), so keep the dotted catalogue id here.
-    modelId: 'anthropic/claude-sonnet-4.6',
+    modelId: 'anthropic/claude-sonnet-5',
   }
 
   protected override async getToolDefinitions(): Promise<ToolDefinition<unknown, unknown>[]> {

--- a/src/server/modules/autonomous-agents/researcher-agent.ts
+++ b/src/server/modules/autonomous-agents/researcher-agent.ts
@@ -91,7 +91,7 @@ export class ResearcherAgent extends AutonomousAgent<Env, AutonomousAgentState> 
     persona: RESEARCHER_PERSONA,
     // Flagship for research strategy + grounding. Writer downshifts
     // to Haiku for the composition step. Cost stays bounded.
-    modelId: 'anthropic/claude-sonnet-4.6',
+    modelId: 'anthropic/claude-sonnet-5',
   }
 
   protected override async getToolDefinitions(): Promise<ToolDefinition<unknown, unknown>[]> {

--- a/src/server/modules/batch-tasks/db/schema.ts
+++ b/src/server/modules/batch-tasks/db/schema.ts
@@ -28,7 +28,7 @@ export const batchJobs = sqliteTable(
     instruction: text('instruction').notNull(),
     /** Loose categorisation for filtering; the agent picks one of these. */
     taskKind: text('task_kind').notNull(), // 'extract' | 'transform' | 'classify' | 'summarise' | 'free'
-    /** Model id used for every item (e.g. 'anthropic/claude-sonnet-4.6'). */
+    /** Model id used for every item (e.g. 'anthropic/claude-sonnet-5'). */
     model: text('model').notNull(),
     /** queued | running | completed | failed | cancelled */
     status: text('status').notNull().default('queued'),

--- a/src/server/modules/chat/tools/batch-task.ts
+++ b/src/server/modules/chat/tools/batch-task.ts
@@ -71,7 +71,7 @@ const StartBatchTaskInput = z.object({
     .string()
     .optional()
     .describe(
-      'Override the per-item model (default: anthropic/claude-sonnet-4.6). Use cheaper models for high-volume simple tasks.'
+      'Override the per-item model (default: anthropic/claude-sonnet-5). Use cheaper models for high-volume simple tasks.'
     ),
 })
 
@@ -92,7 +92,7 @@ const StartBatchTaskOutput = z.union([
   }),
 ])
 
-const DEFAULT_MODEL = 'anthropic/claude-sonnet-4.6'
+const DEFAULT_MODEL = 'anthropic/claude-sonnet-5'
 
 function getEnv(ctx: AgentContext): BatchTaskEnv | undefined {
   const env = ctx.env as Partial<BatchTaskEnv>

--- a/src/server/modules/chat/tools/with-review.ts
+++ b/src/server/modules/chat/tools/with-review.ts
@@ -45,7 +45,7 @@ interface ReviewEnv {
 }
 
 const DEFAULT_WORKER = 'anthropic/claude-haiku-4.5'
-const DEFAULT_REVIEWER = 'anthropic/claude-sonnet-4.6'
+const DEFAULT_REVIEWER = 'anthropic/claude-sonnet-5'
 
 const VERDICT_REGEX = /^VERDICT:\s*(APPROVE|REVISE|REJECT)\s*[—\-]\s*(.+)$/m
 

--- a/src/shared/config/models.ts
+++ b/src/shared/config/models.ts
@@ -9,7 +9,7 @@
  *
  * Format:
  * - `@cf/...`  → free Cloudflare Workers AI (no API key required)
- * - `provider/model` (e.g. `anthropic/claude-sonnet-4.6`) → routed through
+ * - `provider/model` (e.g. `anthropic/claude-sonnet-5`) → routed through
  *   OpenRouter. Requires OPENROUTER_API_KEY secret.
  *
  * Browse the full catalogue at https://models.flared.au/ and just paste the
@@ -36,30 +36,32 @@ export const WORKERS_AI_MODELS = [
 export const OPENROUTER_MODELS = [
   // Anthropic
   'anthropic/claude-opus-4.8', // 1M ctx; $5/$25 per Mtok (4.6 retired from catalogue 2026-05)
-  'anthropic/claude-sonnet-4.6',
+  'anthropic/claude-sonnet-5', // 1M ctx; $2/$10 per Mtok intro to 2026-08-31 ($3/$15 after). Replaced sonnet-4.6 (dropped from catalogue 2026-07)
   'anthropic/claude-haiku-4.5',
 
   // OpenAI
-  'openai/gpt-5.4',
+  'openai/gpt-5.5', // 1M ctx; $5/$30 per Mtok. Replaced gpt-5.4 (dropped from catalogue 2026-07)
   'openai/gpt-5.4-mini',
 
   // Google
   'google/gemini-3.1-pro-preview',
   'google/gemini-3-flash-preview',
 
-  // DeepSeek — V4 dropped 2026-04-24, MIT license, 1M context.
-  // V3.2-speciale retired (deepseek-chat/reasoner endpoints sunset 2026-07-24).
-  'deepseek/deepseek-v4-pro', // 1.6T MoE, 49B active; $1.74/$3.48 per Mtok
-  'deepseek/deepseek-v4-flash', // 284B MoE, 13B active; $0.14/$0.28 per Mtok
+  // DeepSeek — both V4 IDs dropped from catalogue 2026-07; the dated 0731
+  // re-release is the only current V4. No V4-pro successor as of 2026-08.
+  'deepseek/deepseek-v4-flash-0731', // 1M ctx; $0.09/$0.18 per Mtok, reasoning tier
+
+  // Moonshot (OpenRouter route; Workers AI kimi-k2.6 stays the free default)
+  'moonshotai/kimi-k3', // 1M ctx; $3/$15 per Mtok — Kimi successor, added to catalogue 2026-07
 
   // Qwen
-  'qwen/qwen3.6-plus',
+  'qwen/qwen3.7-plus', // 1M ctx; $0.32/$1.28 per Mtok. Replaced qwen3.6-plus (dropped 2026-07)
 
   // Mistral
   'mistralai/mistral-large-2512',
 
   // xAI
-  'x-ai/grok-4.20', // 2M ctx; $1.25/$2.50 per Mtok — same price as grok-4.3, double the context
+  'x-ai/grok-4.5', // 500K ctx; $2/$6 per Mtok. Replaced grok-4.20 (dropped from catalogue 2026-07)
 
   // Z.AI
   'z-ai/glm-5',

--- a/src/shared/data/models-snapshot.json
+++ b/src/shared/data/models-snapshot.json
@@ -1,15 +1,15 @@
 {
-  "updated": "2026-07-25T21:05:30.327Z",
-  "total": 127,
+  "updated": "2026-08-04T06:03:06.576Z",
+  "total": 123,
   "sources": {
     "openrouter": {
       "url": "https://models.flared.au/json",
-      "updated": "2026-07-25T21:05:30.349Z",
-      "count": 101
+      "updated": "2026-08-04T06:03:06.548Z",
+      "count": 97
     },
     "workersai": {
       "url": "https://ai.flared.au/json",
-      "updated": "2026-07-25T21:05:30.360Z",
+      "updated": "2026-08-04T06:03:05.000Z",
       "count": 61
     }
   },
@@ -496,6 +496,43 @@
       "flagship": true
     },
     {
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "name": "DeepSeek: DeepSeek V4 Flash 0731",
+      "short_name": "DeepSeek V4 Flash 0731",
+      "source": "openrouter",
+      "provider": "deepseek",
+      "api_id": "deepseek-v4-flash-0731",
+      "env_var": "DEEPSEEK_API_KEY",
+      "context_length": 1048576,
+      "max_output": 65536,
+      "pricing": {
+        "input": 0.09,
+        "output": 0.18
+      },
+      "modality": "text->text",
+      "category": "text",
+      "capabilities": {
+        "tools": true,
+        "vision": false,
+        "pdf": false,
+        "audio_in": false,
+        "video_in": false,
+        "reasoning": true,
+        "structured_outputs": true,
+        "streaming": true
+      },
+      "tier": "reasoning",
+      "example": {
+        "via": "direct",
+        "endpoint": "https://api.deepseek.com/chat/completions",
+        "curl": "curl https://api.deepseek.com/chat/completions \\\n  -H \"Authorization: Bearer $DEEPSEEK_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"deepseek-v4-flash-0731\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
+      },
+      "released": "2026-07-31",
+      "knowledge_cutoff": null,
+      "sunset_date": null,
+      "flagship": false
+    },
+    {
       "id": "google/gemini-3.1-pro-preview",
       "name": "Google: Gemini 3.1 Pro Preview",
       "short_name": "Gemini 3.1 Pro Preview",
@@ -763,10 +800,10 @@
       "api_id": null,
       "env_var": "OPENROUTER_API_KEY",
       "context_length": 131072,
-      "max_output": 128000,
+      "max_output": 16384,
       "pricing": {
-        "input": 0.13,
-        "output": 0.4
+        "input": 0.1,
+        "output": 0.32
       },
       "modality": "text->text",
       "category": "text",
@@ -1061,7 +1098,7 @@
       "context_length": 262144,
       "max_output": 262144,
       "pricing": {
-        "input": 0.78,
+        "input": 0.73,
         "output": 3.5
       },
       "modality": "text+image->text",
@@ -1199,43 +1236,6 @@
       "flagship": true
     },
     {
-      "id": "openai/gpt-5.6-luna-pro",
-      "name": "OpenAI: GPT-5.6 Luna Pro",
-      "short_name": "GPT-5.6 Luna Pro",
-      "source": "openrouter",
-      "provider": "openai",
-      "api_id": "gpt-5.6-luna-pro",
-      "env_var": "OPENAI_API_KEY",
-      "context_length": 1050000,
-      "max_output": 128000,
-      "pricing": {
-        "input": 1,
-        "output": 6
-      },
-      "modality": "text+image+file->text",
-      "category": "text",
-      "capabilities": {
-        "tools": true,
-        "vision": true,
-        "pdf": true,
-        "audio_in": false,
-        "video_in": false,
-        "reasoning": true,
-        "structured_outputs": true,
-        "streaming": true
-      },
-      "tier": "flagship",
-      "example": {
-        "via": "direct",
-        "endpoint": "https://api.openai.com/v1/chat/completions",
-        "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"gpt-5.6-luna-pro\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
-      },
-      "released": "2026-07-09",
-      "knowledge_cutoff": "2026-02-16",
-      "sunset_date": null,
-      "flagship": true
-    },
-    {
       "id": "openai/gpt-5.4-mini",
       "name": "OpenAI: GPT-5.4 Mini",
       "short_name": "GPT-5.4 Mini",
@@ -1269,6 +1269,43 @@
       },
       "released": "2026-03-17",
       "knowledge_cutoff": "2025-08-31",
+      "sunset_date": null,
+      "flagship": true
+    },
+    {
+      "id": "openai/gpt-5.6-luna-pro",
+      "name": "OpenAI: GPT-5.6 Luna Pro",
+      "short_name": "GPT-5.6 Luna Pro",
+      "source": "openrouter",
+      "provider": "openai",
+      "api_id": "gpt-5.6-luna-pro",
+      "env_var": "OPENAI_API_KEY",
+      "context_length": 1050000,
+      "max_output": 128000,
+      "pricing": {
+        "input": 0.1,
+        "output": 0.6
+      },
+      "modality": "text+image+file->text",
+      "category": "text",
+      "capabilities": {
+        "tools": true,
+        "vision": true,
+        "pdf": true,
+        "audio_in": false,
+        "video_in": false,
+        "reasoning": true,
+        "structured_outputs": true,
+        "streaming": true
+      },
+      "tier": "flagship",
+      "example": {
+        "via": "direct",
+        "endpoint": "https://api.openai.com/v1/chat/completions",
+        "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"gpt-5.6-luna-pro\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
+      },
+      "released": "2026-07-09",
+      "knowledge_cutoff": "2026-02-16",
       "sunset_date": null,
       "flagship": true
     },
@@ -1347,43 +1384,6 @@
       "flagship": false
     },
     {
-      "id": "openai/gpt-chat-latest",
-      "name": "OpenAI: GPT Chat Latest",
-      "short_name": "GPT Chat Latest",
-      "source": "openrouter",
-      "provider": "openai",
-      "api_id": "gpt-chat-latest",
-      "env_var": "OPENAI_API_KEY",
-      "context_length": 400000,
-      "max_output": 128000,
-      "pricing": {
-        "input": 5,
-        "output": 30
-      },
-      "modality": "text+image+file->text",
-      "category": "text",
-      "capabilities": {
-        "tools": true,
-        "vision": true,
-        "pdf": true,
-        "audio_in": false,
-        "video_in": false,
-        "reasoning": false,
-        "structured_outputs": true,
-        "streaming": true
-      },
-      "tier": "balanced",
-      "example": {
-        "via": "direct",
-        "endpoint": "https://api.openai.com/v1/chat/completions",
-        "curl": "curl https://api.openai.com/v1/chat/completions \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"gpt-chat-latest\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
-      },
-      "released": "2026-05-05",
-      "knowledge_cutoff": null,
-      "sunset_date": null,
-      "flagship": false
-    },
-    {
       "id": "openai/gpt-5.6-terra-pro",
       "name": "OpenAI: GPT-5.6 Terra Pro",
       "short_name": "GPT-5.6 Terra Pro",
@@ -1394,8 +1394,8 @@
       "context_length": 1050000,
       "max_output": 128000,
       "pricing": {
-        "input": 2.5,
-        "output": 15
+        "input": 1,
+        "output": 6
       },
       "modality": "text+image+file->text",
       "category": "text",
@@ -1431,8 +1431,8 @@
       "context_length": 1050000,
       "max_output": 128000,
       "pricing": {
-        "input": 2.5,
-        "output": 15
+        "input": 1,
+        "output": 6
       },
       "modality": "text+image+file->text",
       "category": "text",
@@ -1468,8 +1468,8 @@
       "context_length": 1050000,
       "max_output": 128000,
       "pricing": {
-        "input": 1,
-        "output": 6
+        "input": 0.1,
+        "output": 0.6
       },
       "modality": "text+image+file->text",
       "category": "text",
@@ -1495,27 +1495,27 @@
       "flagship": false
     },
     {
-      "id": "qwen/qwen3.7-max",
-      "name": "Qwen: Qwen3.7 Max",
-      "short_name": "Qwen3.7 Max",
+      "id": "qwen/qwen3.8-max",
+      "name": "Qwen: Qwen3.8 Max",
+      "short_name": "Qwen3.8 Max",
       "source": "openrouter",
       "provider": "qwen",
-      "api_id": "qwen3.7-max",
+      "api_id": "qwen3.8-max",
       "env_var": "DASHSCOPE_API_KEY",
       "context_length": 1000000,
-      "max_output": 65536,
+      "max_output": 131072,
       "pricing": {
-        "input": 1.475,
-        "output": 4.425
+        "input": 2,
+        "output": 6
       },
-      "modality": "text->text",
+      "modality": "text+image+video->text",
       "category": "text",
       "capabilities": {
         "tools": true,
-        "vision": false,
+        "vision": true,
         "pdf": false,
         "audio_in": false,
-        "video_in": false,
+        "video_in": true,
         "reasoning": true,
         "structured_outputs": true,
         "streaming": true
@@ -1524,9 +1524,9 @@
       "example": {
         "via": "direct",
         "endpoint": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
-        "curl": "curl https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions \\\n  -H \"Authorization: Bearer $DASHSCOPE_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"qwen3.7-max\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
+        "curl": "curl https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions \\\n  -H \"Authorization: Bearer $DASHSCOPE_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"qwen3.8-max\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
       },
-      "released": "2026-05-21",
+      "released": "2026-08-03",
       "knowledge_cutoff": null,
       "sunset_date": null,
       "flagship": true
@@ -1540,7 +1540,7 @@
       "api_id": "qwen3.7-plus",
       "env_var": "DASHSCOPE_API_KEY",
       "context_length": 1000000,
-      "max_output": 65536,
+      "max_output": 131072,
       "pricing": {
         "input": 0.32,
         "output": 1.28
@@ -1569,18 +1569,18 @@
       "flagship": true
     },
     {
-      "id": "qwen/qwen3.6-flash",
-      "name": "Qwen: Qwen3.6 Flash",
-      "short_name": "Qwen3.6 Flash",
+      "id": "qwen/qwen3.7-flash",
+      "name": "Qwen: Qwen3.7 Flash",
+      "short_name": "Qwen3.7 Flash",
       "source": "openrouter",
       "provider": "qwen",
-      "api_id": "qwen3.6-flash",
+      "api_id": "qwen3.7-flash",
       "env_var": "DASHSCOPE_API_KEY",
       "context_length": 1000000,
       "max_output": 65536,
       "pricing": {
-        "input": 0.1875,
-        "output": 1.125
+        "input": 0.03,
+        "output": 0.13
       },
       "modality": "text+image+video->text",
       "category": "text",
@@ -1598,26 +1598,26 @@
       "example": {
         "via": "direct",
         "endpoint": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
-        "curl": "curl https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions \\\n  -H \"Authorization: Bearer $DASHSCOPE_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"qwen3.6-flash\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
+        "curl": "curl https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions \\\n  -H \"Authorization: Bearer $DASHSCOPE_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"qwen3.7-flash\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
       },
-      "released": "2026-04-27",
+      "released": "2026-07-27",
       "knowledge_cutoff": null,
       "sunset_date": null,
       "flagship": true
     },
     {
-      "id": "qwen/qwen3.6-max-preview",
-      "name": "Qwen: Qwen3.6 Max Preview",
-      "short_name": "Qwen3.6 Max Preview",
+      "id": "qwen/qwen3.7-max",
+      "name": "Qwen: Qwen3.7 Max",
+      "short_name": "Qwen3.7 Max",
       "source": "openrouter",
       "provider": "qwen",
-      "api_id": "qwen3.6-max-preview",
+      "api_id": "qwen3.7-max",
       "env_var": "DASHSCOPE_API_KEY",
-      "context_length": 262144,
-      "max_output": 65536,
+      "context_length": 1000000,
+      "max_output": 131072,
       "pricing": {
-        "input": 1.04,
-        "output": 6.24
+        "input": 1.475,
+        "output": 4.425
       },
       "modality": "text->text",
       "category": "text",
@@ -1635,120 +1635,9 @@
       "example": {
         "via": "direct",
         "endpoint": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
-        "curl": "curl https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions \\\n  -H \"Authorization: Bearer $DASHSCOPE_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"qwen3.6-max-preview\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
+        "curl": "curl https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions \\\n  -H \"Authorization: Bearer $DASHSCOPE_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"qwen3.7-max\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
       },
-      "released": "2026-04-27",
-      "knowledge_cutoff": null,
-      "sunset_date": null,
-      "flagship": false
-    },
-    {
-      "id": "qwen/qwen3.5-plus-20260420",
-      "name": "Qwen: Qwen3.5 Plus 2026-04-20",
-      "short_name": "Qwen3.5 Plus 2026-04-20",
-      "source": "openrouter",
-      "provider": "qwen",
-      "api_id": "qwen3.5-plus-20260420",
-      "env_var": "DASHSCOPE_API_KEY",
-      "context_length": 1000000,
-      "max_output": 65536,
-      "pricing": {
-        "input": 0.3,
-        "output": 1.8
-      },
-      "modality": "text+image+video->text",
-      "category": "text",
-      "capabilities": {
-        "tools": true,
-        "vision": true,
-        "pdf": false,
-        "audio_in": false,
-        "video_in": true,
-        "reasoning": true,
-        "structured_outputs": true,
-        "streaming": true
-      },
-      "tier": "reasoning",
-      "example": {
-        "via": "direct",
-        "endpoint": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
-        "curl": "curl https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions \\\n  -H \"Authorization: Bearer $DASHSCOPE_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"qwen3.5-plus-20260420\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
-      },
-      "released": "2026-04-27",
-      "knowledge_cutoff": null,
-      "sunset_date": null,
-      "flagship": false
-    },
-    {
-      "id": "qwen/qwen3.6-27b",
-      "name": "Qwen: Qwen3.6 27B",
-      "short_name": "Qwen3.6 27B",
-      "source": "openrouter",
-      "provider": "qwen",
-      "api_id": "qwen3.6-27b",
-      "env_var": "DASHSCOPE_API_KEY",
-      "context_length": 262144,
-      "max_output": 131072,
-      "pricing": {
-        "input": 0.289,
-        "output": 2.4
-      },
-      "modality": "text+image+video->text",
-      "category": "text",
-      "capabilities": {
-        "tools": true,
-        "vision": true,
-        "pdf": false,
-        "audio_in": false,
-        "video_in": true,
-        "reasoning": true,
-        "structured_outputs": true,
-        "streaming": true
-      },
-      "tier": "reasoning",
-      "example": {
-        "via": "direct",
-        "endpoint": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
-        "curl": "curl https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions \\\n  -H \"Authorization: Bearer $DASHSCOPE_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"qwen3.6-27b\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
-      },
-      "released": "2026-04-27",
-      "knowledge_cutoff": null,
-      "sunset_date": null,
-      "flagship": false
-    },
-    {
-      "id": "qwen/qwen3.6-35b-a3b",
-      "name": "Qwen: Qwen3.6 35B A3B",
-      "short_name": "Qwen3.6 35B A3B",
-      "source": "openrouter",
-      "provider": "qwen",
-      "api_id": "qwen3.6-35b-a3b",
-      "env_var": "DASHSCOPE_API_KEY",
-      "context_length": 262144,
-      "max_output": 262144,
-      "pricing": {
-        "input": 0.14,
-        "output": 1
-      },
-      "modality": "text+image+video->text",
-      "category": "text",
-      "capabilities": {
-        "tools": true,
-        "vision": true,
-        "pdf": false,
-        "audio_in": false,
-        "video_in": true,
-        "reasoning": true,
-        "structured_outputs": true,
-        "streaming": true
-      },
-      "tier": "reasoning",
-      "example": {
-        "via": "direct",
-        "endpoint": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
-        "curl": "curl https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions \\\n  -H \"Authorization: Bearer $DASHSCOPE_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"qwen3.6-35b-a3b\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
-      },
-      "released": "2026-04-27",
+      "released": "2026-05-21",
       "knowledge_cutoff": null,
       "sunset_date": null,
       "flagship": false
@@ -1826,43 +1715,6 @@
       "knowledge_cutoff": null,
       "sunset_date": null,
       "flagship": true
-    },
-    {
-      "id": "x-ai/grok-4.3",
-      "name": "xAI: Grok 4.3",
-      "short_name": "Grok 4.3",
-      "source": "openrouter",
-      "provider": "x-ai",
-      "api_id": "grok-4.3",
-      "env_var": "XAI_API_KEY",
-      "context_length": 1000000,
-      "max_output": null,
-      "pricing": {
-        "input": 1.25,
-        "output": 2.5
-      },
-      "modality": "text+image+file->text",
-      "category": "text",
-      "capabilities": {
-        "tools": true,
-        "vision": true,
-        "pdf": true,
-        "audio_in": false,
-        "video_in": false,
-        "reasoning": true,
-        "structured_outputs": true,
-        "streaming": true
-      },
-      "tier": "reasoning",
-      "example": {
-        "via": "direct",
-        "endpoint": "https://api.x.ai/v1/chat/completions",
-        "curl": "curl https://api.x.ai/v1/chat/completions \\\n  -H \"Authorization: Bearer $XAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"grok-4.3\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}]}'"
-      },
-      "released": "2026-04-30",
-      "knowledge_cutoff": null,
-      "sunset_date": null,
-      "flagship": false
     },
     {
       "id": "x-ai/grok-build-0.1",
@@ -1984,10 +1836,10 @@
       "api_id": null,
       "env_var": "OPENROUTER_API_KEY",
       "context_length": 1048576,
-      "max_output": 131072,
+      "max_output": 262144,
       "pricing": {
-        "input": 0.7,
-        "output": 2.2
+        "input": 0.76,
+        "output": 2.42
       },
       "modality": "text->text",
       "category": "text",
@@ -2057,7 +1909,7 @@
       "provider": "google",
       "api_id": "gemini-3.1-flash-image-preview",
       "env_var": "GEMINI_API_KEY",
-      "context_length": 131072,
+      "context_length": 65536,
       "max_output": 65536,
       "pricing": {
         "input": 0.5,
@@ -2169,7 +2021,7 @@
       "api_id": "gemini-3.1-flash-lite-image",
       "env_var": "GEMINI_API_KEY",
       "context_length": 65536,
-      "max_output": 66000,
+      "max_output": 65536,
       "pricing": {
         "input": 0.25,
         "output": 1.5


### PR DESCRIPTION
Completes the action-required half of #121 (the July pass refreshed the snapshot; this resolves the 6 stale IDs it flagged, against a fresh 2026-08-04 snapshot).

## Replacements (all verified in the live flared.au catalogue, pricing from the snapshot)

| Stale | Replacement |
|---|---|
| `anthropic/claude-sonnet-4.6` | `anthropic/claude-sonnet-5` (1M ctx, $2/$10 intro to 2026-08-31) |
| `openai/gpt-5.4` | `openai/gpt-5.5` (`gpt-5.4-mini` still current, kept) |
| `deepseek/deepseek-v4-pro` + `v4-flash` | `deepseek/deepseek-v4-flash-0731` (only current V4; no pro successor yet) |
| `qwen/qwen3.6-plus` | `qwen/qwen3.7-plus` |
| `x-ai/grok-4.20` | `x-ai/grok-4.5` (500K ctx vs 4.20's 2M — catalogue has no closer successor) |
| — | **added** `moonshotai/kimi-k3` (new 2026-07; keeps the curated set at 20) |

## Beyond models.ts

The issue only named `models.ts`, but five live defaults also pointed at the retired OpenRouter route and would fail at runtime: `ALIAS_TO_MODEL_ID` (sonnet/gpt/deepseek/qwen/grok aliases), `start_batch_task` DEFAULT_MODEL, `with_review` DEFAULT_REVIEWER, admin-agent + researcher-agent `modelId`, and the gateway's OpenRouter catalog entry. All updated.

**Deliberately unchanged:** the gateway's direct-Anthropic entry `claude-sonnet-4-6` (dash format) — verified against current Anthropic model documentation that it's still an active direct-API model; only OpenRouter's catalogue dropped it.

## Verified

- `pnpm doctor:models` green — 16/16 enabled models in catalogue, all `@cf/` IDs current
- 291/291 unit tests, type-check clean
- Not live-verified through OpenRouter (needs a deployed chat session; the IDs are pasted verbatim from the live catalogue feed)

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)