### PR TITLE
docs(kanban): optimistic-move mutation recipe with 409 conflict handling (#118)

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -105,6 +105,81 @@ export function useCreateYourData() {
 
 ---
 
+## Kanban Optimistic Move (conflict-safe)
+
+The `KanbanBoard` primitive fires `onCardMove` once per completed drag and
+re-derives from props — persistence and recovery are the consumer's job
+(see the header of `src/components/ui/kanban.tsx`). Every real consumer
+pairs it with this mutation shape. The subtle parts, in order: cancel
+in-flight queries **before** snapshotting (or a late response clobbers your
+optimistic write), revert from the snapshot in `onError`, and invalidate on
+settle either way.
+
+```typescript
+// Working baseline: src/client/modules/kanban-demo/hooks/useTaskEntities.ts (useMoveTask)
+export function useMoveCard() {
+  const queryClient = useQueryClient()
+  return useMutation<Card, Error, MoveInput, { prev?: BoardData }>({
+    mutationFn: ({ id, column, position, updatedAt }) =>
+      apiClient.patch<Card>(`/api/cards/${id}`, {
+        fields: { column, position },
+        // Optimistic-lock token — see "Concurrent writers" below.
+        expectedUpdatedAt: updatedAt,
+      }),
+    onMutate: async ({ id, column, position }) => {
+      await queryClient.cancelQueries({ queryKey: BOARD_KEY }) // BEFORE snapshot
+      const prev = queryClient.getQueryData<BoardData>(BOARD_KEY)
+      if (prev) {
+        queryClient.setQueryData<BoardData>(BOARD_KEY, {
+          ...prev,
+          cards: prev.cards.map((c) =>
+            c.id === id ? { ...c, fields: { ...c.fields, column, position } } : c
+          ),
+        })
+      }
+      return { prev }
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.prev) queryClient.setQueryData(BOARD_KEY, ctx.prev)
+      // ApiError is an interface, not a class — no instanceof; read .status
+      if ((err as Partial<ApiError>).status === 409) {
+        toast.error('Card changed since you loaded it — board refreshed, try again.')
+      }
+    },
+    onSettled: () => {
+      // Invalidate every key that renders this card (board list + detail views)
+      queryClient.invalidateQueries({ queryKey: BOARD_KEY })
+      queryClient.invalidateQueries({ queryKey: CARD_KEY })
+    },
+  })
+}
+```
+
+**Concurrent writers (agents moving cards too).** When a cron agent or
+another user moves cards as often as humans do, add an optimistic lock so
+a stale drag can't silently overwrite a newer move: send the `updatedAt`
+you rendered from as `expectedUpdatedAt`, and have the PATCH handler
+compare-and-409 before writing:
+
+```typescript
+// In your module's PATCH route — one extra guard before the update
+const row = await getCard(db, id)
+if (body.expectedUpdatedAt && row.updatedAt !== body.expectedUpdatedAt) {
+  return c.json({ error: 'Conflict: card changed since it was loaded' }, 409)
+}
+```
+
+The 409 branch in `onError` above then reverts the cache and tells the
+user. Without the token, last-write-wins — acceptable for single-user
+boards (the bundled `/api/entities` PATCH works this way), wrong for
+boards with agent writers.
+
+**Reference:** `src/client/modules/kanban-demo/hooks/useTaskEntities.ts`
+(baseline, no lock token — the demo's entities API is last-write-wins) ·
+`src/components/ui/kanban.tsx` header (the primitive's side of the contract)
+
+---
+
 ## AI Streaming Chat (ToolLoopAgent)
 
 ```typescript

--- a/src/components/ui/kanban.tsx
+++ b/src/components/ui/kanban.tsx
@@ -12,7 +12,10 @@
  *   - how to recover from persistence errors (caller does optimistic
  *     update locally; primitive fires `onCardMove` once per completed
  *     move and re-derives from props — if the server rejects, restore
- *     the previous state in your TanStack Query mutation `onError`)
+ *     the previous state in your TanStack Query mutation `onError`).
+ *     The full mutation recipe — optimistic update, 409 optimistic-lock
+ *     revert for boards with concurrent/agent writers, invalidation —
+ *     is in docs/PATTERNS.md § "Kanban Optimistic Move (conflict-safe)".
  *
  * Ordering uses **fractional-index string keys** (`fractional-indexing`):
  * each card holds a `position` string; a move is ONE row update, never a


### PR DESCRIPTION
Takes option 1 from #118 (document the recipe) — the issue's own analysis that an exported `useKanbanMoveMutation` is the wrong altitude (TanStack key shapes are app-specific) held up when I checked the demo consumer.

## What

New **"Kanban Optimistic Move (conflict-safe)"** section in `docs/PATTERNS.md`, placed after the TanStack Query Hook section, plus a discoverability pointer in the `kanban.tsx` header (which already described the contract but not the recipe).

The recipe covers the four beats from the issue: cancel-then-snapshot on mutate, optimistic-lock token (`expectedUpdatedAt`), 409 revert + toast, invalidate both board and card keys on settle. The baseline is lifted from the **working** `kanban-demo` `useMoveTask` hook; the 409/lock half is marked explicitly as requiring server support, with a compare-and-409 sketch for the PATCH handler — the bundled `/api/entities` PATCH is last-write-wins today, and the doc says so rather than implying the demo already 409s.

One correctness detail: the snippet reads `(err as Partial<ApiError>).status` because `ApiError` in `api-client.ts` is an **interface**, not a class — an `instanceof` check (my first draft, and a likely copy-paste instinct) doesn't work.

@ the #118 reporter: if your working support-ticket-board mutation differs from this shape anywhere that matters, corrections welcome — this was reconstructed from the issue description + the demo hook, not your implementation.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)