### PR TITLE
Deliberate design at fork: placeholder theme, brand-extraction step 0, DESIGN_BRIEF template

### DIFF
--- a/.claude/rules/design-tokens.md
+++ b/.claude/rules/design-tokens.md
@@ -1,41 +1,50 @@
-# Design tokens — Kumo-derived, single-source
+# Design tokens: single-source structure, placeholder values
 
-The design language is Cloudflare-Kumo-derived (2026-07 reboot). `src/index.css` is the
-single source of truth; `src/lib/themes.ts` presets are deliberate inline overrides on top.
-The tool-agnostic description (Google Labs DESIGN.md format, readable by Cursor/Copilot/
-Stitch) lives at the repo root: [`DESIGN.md`](../../DESIGN.md) — update it in the same
-commit as any token change.
+`src/index.css` is the single source of truth; `src/lib/themes.ts` presets are
+demo-only inline overrides on top (deleted at fork, see FORKING.md Part 0). The
+tool-agnostic description (Google Labs DESIGN.md format, readable by Cursor/
+Copilot/Stitch) lives at the repo root: [`DESIGN.md`](../../DESIGN.md), update
+it in the same commit as any token change.
 
-## The rules
+The VALUES in index.css are the placeholder theme (Kumo-derived, 2026-07
+reboot). The STRUCTURE is the contract. **Forks: deviation from VALUES is
+mandatory; deviation from STRUCTURE is the smell.** A fork extracts the
+client's real brand and rewrites every value before building any product
+surface (FORKING.md Part 0, DESIGN_BRIEF.md). Per-product semantic scales are
+blessed: name new tokens in the product's own language (the brand/brass/clay
+pattern) rather than forcing a brand into the placeholder's vocabulary.
 
-- **Semantic tokens only** in app code: `bg-background/card/surface-elevated/surface-recessed/
-  surface-tint`, `text-foreground/muted-foreground`, `border-border/hairline`, `bg-info-tint`
-  etc. Raw palette classes (`bg-blue-500`, `text-gray-900`) are a smell — if no token fits,
-  add a token.
-- **Never write a `.dark { --token: … }` block or `dark:` color variant for theming.** Every
-  token declares both modes via `light-dark()` in `:root`; `.dark` only flips `color-scheme`.
-  (`dark:` stays legitimate for rare non-color tweaks.)
-- **Two border weights**: `border-border` ("line", alpha) for interactive/structural edges;
-  `border-hairline` for quiet dividers (sidebar, breadcrumb strips, tab bars). Don't invent a
-  third.
-- **Primary is blue, orange is brand-accent only** (CF convention). Focus ring is neutral.
-- **Density comes from the global text scale** (base 14px / sm 13px / xs 12px in `@theme`)
-  — don't sprinkle `text-[13px]` to densify; the scale already did it. `tabular-nums` on
-  data numbers.
-- **Page anatomy** is PageHeader's job (breadcrumbs strip → 3xl title → max-w-prose subtitle
-  → tabs). No hand-rolled page headers.
+## The rules (structure, survives every fork)
+
+- **Semantic tokens only** in app code: `bg-background/card/surface-elevated/
+  surface-recessed/surface-tint`, `text-foreground/muted-foreground`,
+  `border-border/hairline`, `bg-info-tint` etc. If no token fits, add a token.
+- **Never write a `.dark { --token: … }` block or `dark:` color variant for
+  theming.** Every token declares both modes via `light-dark()` in `:root`;
+  `.dark` only flips `color-scheme`. (`dark:` stays legitimate for rare
+  non-color tweaks.)
+- **Two border weights**: `border-border` ("line", alpha) for interactive/
+  structural edges; `border-hairline` for quiet dividers (sidebar, breadcrumb
+  strips, tab bars). Don't invent a third.
+- **Density comes from the global text scale** (base 14px / sm 13px / xs 12px
+  in `@theme`), don't sprinkle `text-[13px]` to densify; the scale already did
+  it. `tabular-nums` on data numbers.
+- **Page anatomy** is PageHeader's job (breadcrumbs strip → 3xl title →
+  max-w-prose subtitle → tabs). No hand-rolled page headers.
 
 ## Kumo interop (charts)
 
-Kumo's Chart/TimeseriesChart DOM needs `kumo-*` utilities: generated via the `@source` glob in
-index.css + `--color-kumo-*` vars mapped onto ours. If chart tooltips lose styling after a
-Kumo upgrade, the chunk glob is the tell. Canvas can't read CSS vars — resolve colors through
-`useChartTheme` (`@/client/lib/echarts`).
+Kumo's Chart/TimeseriesChart DOM needs `kumo-*` utilities: generated via the
+`@source` glob in index.css + `--color-kumo-*` vars mapped onto ours. If chart
+tooltips lose styling after a Kumo upgrade, the chunk glob is the tell. Canvas
+can't read CSS vars, so resolve colors through `useChartTheme`
+(`@/client/lib/echarts`).
 
 ## Failure mode this prevents
 
-A new module hand-picks hexes/palette classes, adds a `.dark` override block, and the app
-drifts back to three sources of truth that disagree in one mode. The 2026-07 reboot removed
-exactly that (themes.ts silently overrode index.css for two months).
+A new module hand-picks hexes/palette classes, adds a `.dark` override block,
+and the app drifts back to three sources of truth that disagree in one mode.
+The 2026-07 reboot removed exactly that (themes.ts silently overrode index.css
+for two months).
 
-**Last Updated**: 2026-07-16
+**Last Updated**: 2026-08-16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ are good templates — copy that shape and triage stays under a minute.
 `TOKEN_PREFIX`, `index.html` title, favicon in `public/`. Set
 `VITE_GITHUB_URL=""` to hide GitHub links.
 
+**No product surface until [`DESIGN_BRIEF.md`](./DESIGN_BRIEF.md) is filled from real material; no material → design deliberately, never inherit the placeholder** ([`FORKING.md`](./FORKING.md) Part 0).
+
 ---
 
 ## Where to find things

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,10 +26,14 @@ components:
 
 # Vite Flare Starter — Design
 
-> **Canonical source: `src/index.css`.** Every token there declares both
-> light and dark values via `light-dark()`. This file describes the
-> system for humans and coding agents; when the two disagree, the CSS
-> wins — update this file in the same commit as a token change.
+> **This is the placeholder language, superseded by
+> [`DESIGN_BRIEF.md`](./DESIGN_BRIEF.md) at fork.** It stays the
+> reference for the starter's default look; a fork extracts the client's
+> real brand and rewrites the token values (FORKING.md Part 0), keeping
+> the structure this file describes. Canonical source: `src/index.css`.
+> Every token there declares both light and dark values via
+> `light-dark()`; when this file and the CSS disagree, the CSS wins.
+> Update this file in the same commit as a token change.
 
 ## Overview (Brand & Style)
 

--- a/DESIGN_BRIEF.md
+++ b/DESIGN_BRIEF.md
@@ -1,0 +1,72 @@
+# Design Brief
+
+> **This file ships unfilled, and that is the point.** An unfilled slot
+> below means the app is still wearing the placeholder theme. Fill every
+> slot from real material before building any product surface (see
+> [`FORKING.md`](./FORKING.md) Part 0). No real material? Design
+> deliberately anyway and record what you chose and why. The neutral
+> default is decent and an internal tool may keep it, but write that
+> down here as a choice. Never inherit the placeholder by accident.
+
+## Client
+
+`[ UNFILLED: who is this product for? ]`
+
+## Brand sources
+
+Where the palette and type below came from. Real URLs, real screenshots
+(save them to `.jez/screenshots/brand/` or `docs/brand/`).
+
+| Source | URL | Screenshot |
+|---|---|---|
+| `[ UNFILLED ]` | `[ UNFILLED ]` | `[ UNFILLED ]` |
+
+## Palette
+
+Every colour with provenance: the exact place on the real material it
+was extracted from. "Roughly blue" is not provenance.
+
+| Token | Value | Provenance |
+|---|---|---|
+| `--primary` | `[ UNFILLED ]` | `[ UNFILLED ]` |
+| `--background` (light/dark) | `[ UNFILLED ]` | `[ UNFILLED ]` |
+| `--accent` | `[ UNFILLED ]` | `[ UNFILLED ]` |
+| status hues (info/success/warning) | `[ UNFILLED ]` | `[ UNFILLED ]` |
+
+## Display type
+
+Font, weights, where it appears. Self-hosted from `public/` (FORKING.md
+Step 0.3), never a CDN link.
+
+`[ UNFILLED ]`
+
+## Layout shape
+
+The app's structural idea, not "sidebar + card grid" by default. What
+does the main working surface look like, and why does it fit this
+product's job?
+
+`[ UNFILLED ]`
+
+## Component posture
+
+Which shadcn defaults get reshaped so the components read as this
+product's, not the library's: radius, density, elevation, motion.
+
+`[ UNFILLED ]`
+
+## Voice / register
+
+How the brand speaks: formal, warm, technical, playful. Shapes UI copy,
+empty states, and error messages, not just marketing pages.
+
+`[ UNFILLED ]`
+
+## One signature move
+
+The single distinctive thing this product's design does that the
+placeholder doesn't: a texture, a motion, a layout habit, a colour used
+somewhere unexpected. One is enough; zero means it still looks like the
+starter.
+
+`[ UNFILLED ]`

--- a/FORKING.md
+++ b/FORKING.md
@@ -38,6 +38,64 @@ Before starting:
 
 ---
 
+## Part 0: Brand Extraction
+
+The starter ships a **placeholder theme** (the Kumo-derived look in
+`src/index.css` and `DESIGN.md`). It is deliberately decent, and an
+internal tool may keep it, but keeping it must be a deliberate choice.
+The rule is: **never ship the placeholder without a deliberate choice**,
+not "always custom". Do this part before building any product surface.
+The fork/clone mechanics in Part 1 can come first; the product UI cannot.
+
+### Step 0.1: Gather real brand material
+
+- Fetch the client's real sites (current website, socials, print material
+  if they have it) and **screenshot them**.
+- Extract the palette (actual hex/oklch values from the material, not
+  "roughly blue"), the typography (display + body), and the register
+  (how the brand speaks: formal, warm, technical, playful).
+
+### Step 0.2: Fill in DESIGN_BRIEF.md
+
+Record everything in [`DESIGN_BRIEF.md`](./DESIGN_BRIEF.md) at the repo
+root: client, brand sources with URLs + screenshots, each palette colour
+with its provenance, display type, layout shape, component posture,
+voice/register, and one signature move. An unfilled slot in that file
+means the extraction isn't done.
+
+A palette swap on stock shadcn is still the generic app. **If the
+finished app would be recognisable as shadcn defaults at a glance, the
+design step isn't done: the library is the chassis, never the look.**
+
+If there is **no real material** (new brand, internal tool), design
+deliberately anyway: choose values, record why in the brief, and note
+"kept the neutral default" explicitly if that is the choice.
+
+### Step 0.3: Self-host the display font
+
+Download the chosen display font and serve it from `public/` with
+`@font-face` in `src/index.css`. No Google Fonts CDN link: it adds a
+third-party request and the placeholder look survives font fallback.
+
+### Step 0.4: Rewrite the token values
+
+Rewrite the values in `src/index.css` from the brief, **before any
+product surface is built**. Values are scaffolding; the structure
+(single source, `light-dark()`, semantic tokens, two border weights) is
+the contract and stays. See `.claude/rules/design-tokens.md`.
+
+### Step 0.5: Delete the theme presets
+
+The preset palettes in `src/lib/themes.ts` are demo-only. They apply
+inline CSS variables that **silently override index.css**, which is
+exactly the 2026-07 drift incident (themes.ts overrode index.css for two
+months before anyone noticed; see `.claude/rules/design-tokens.md`).
+Delete them at fork: strip the preset palettes from `themes.ts`, or
+remove the theme picker and the presets with it. Your re-tokened
+index.css must be the only source of truth.
+
+---
+
 ## Part 1: Fork and Initial Setup
 
 > **AI agents — read this first.** When the user says "fork the starter",
@@ -554,6 +612,8 @@ If you don't change these, attackers can identify your site uses this starter:
 
 After completing all steps, verify:
 
+- [ ] `DESIGN_BRIEF.md` is filled from real material (or records a deliberate choice to keep the neutral default)
+- [ ] `src/index.css` token values match the brief; theme presets deleted from `src/lib/themes.ts`
 - [ ] `wrangler.jsonc` has YOUR database_id (not the original)
 - [ ] `wrangler.jsonc` has YOUR bucket names
 - [ ] `wrangler.jsonc` has no `account_id` or has YOUR account_id

--- a/src/index.css
+++ b/src/index.css
@@ -46,21 +46,25 @@
 }
 
 /* ── Design tokens ─────────────────────────────────────────────────────────
- * Kumo-derived design language (@cloudflare/kumo 2.8.0 theme values, adapted
- * onto shadcn variable names so every component picks them up unchanged).
+ * PLACEHOLDER THEME: replacing every value is the first act of a fork.
  *
- * Single source of truth: each token declares BOTH modes via light-dark();
- * there is deliberately no duplicated `.dark { … }` block to drift. The
- * theme-provider's `.dark` class only flips color-scheme (below).
+ * The values below are scaffolding (Kumo-derived, @cloudflare/kumo 2.8.0,
+ * adapted onto shadcn variable names so every component picks them up
+ * unchanged). A fork extracts the client's real brand and rewrites them
+ * all before building any product surface: see FORKING.md Part 0 and
+ * DESIGN_BRIEF.md.
  *
- * Structure (Kumo's surface hierarchy):
- *   canvas (page bg) → base (card) → elevated / recessed / tint
+ * The STRUCTURE is the contract and survives every fork:
+ *   single source of truth: each token declares BOTH modes via light-dark();
+ *   there is deliberately no duplicated `.dark { … }` block to drift (the
+ *   theme-provider's `.dark` class only flips color-scheme, below)
+ *   surface hierarchy: canvas (page bg) → base (card) → elevated / recessed / tint
  *   two border weights: --border ("line", alpha in light) + --hairline
  *   focus ring is NEUTRAL (near-black/near-white), not brand-coloured
- *   primary is blue — CF-style; orange stays a logo/brand accent only
  *
  * Preset/custom themes (src/lib/themes.ts) override these with inline vars;
- * the 'default' scheme applies none and uses exactly these values.
+ * the 'default' scheme applies none and uses exactly these values. The
+ * presets are demo-only and get deleted at fork (FORKING.md Part 0).
  */
 :root {
   color-scheme: light;

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -15,6 +15,13 @@ import { appConfig } from '@/shared/config/app'
  *
  * Each theme has light and dark variants
  * Values are in HSL format (H S% L%)
+ *
+ * DEMO-ONLY PRESETS. These exist so the starter's theme picker has
+ * something to show. They apply inline CSS variables that silently
+ * override src/index.css (the 2026-07 drift incident: themes.ts
+ * overrode index.css for two months). Forks delete the presets at
+ * fork time so the re-tokened index.css is the only source of truth.
+ * See FORKING.md Part 0 (Step 0.5).
  */
 
 type ThemeColors = {


### PR DESCRIPTION
fixes #132

1. `src/index.css`: token header reframed as PLACEHOLDER THEME. Replacing every value is the first act of a fork; values are scaffolding, structure is the contract.
2. `.claude/rules/design-tokens.md`: structural rules kept, brand-loyalty clauses (blue-primary CF convention, orange-accent-only, raw-palette-smell) deleted; added "deviation from VALUES is mandatory; deviation from STRUCTURE is the smell" and blessed per-product semantic scales (brand/brass/clay pattern).
3. `FORKING.md`: new Part 0 "Brand Extraction" before all existing steps: fetch + screenshot the client's real sites, extract palette/type/register, fill the brief, self-host the display font, rewrite token values before any product surface; plus the shadcn-chassis doctrine and two verification-checklist items.
4. New `DESIGN_BRIEF.md` at root: fill-in template (client, brand sources, palette with provenance, display type, layout shape, component posture, voice/register, one signature move) with conspicuously unfilled slots; CLAUDE.md gains the one-line gate: no product surface until it's filled from real material.
5. `src/lib/themes.ts`: presets marked DEMO-ONLY in the header comment; FORKING Step 0.5 says forks delete them (they silently override index.css, the documented 2026-07 drift incident).
6. `DESIGN.md`: intro reframed as the placeholder language, superseded by DESIGN_BRIEF.md at fork; rest kept as the reference for the default look.

Counterweight kept throughout: the neutral default stays decent and internal tools may keep it deliberately. The rule is "never ship the placeholder without a deliberate choice", not "always custom".

🤖 Generated with [Claude Code](https://claude.com/claude-code)